### PR TITLE
Fix location tracker not updating after local member is removed

### DIFF
--- a/src/Space.mockClient.test.ts
+++ b/src/Space.mockClient.test.ts
@@ -397,6 +397,31 @@ describe('Space (mockClient)', () => {
 
         expect(spy).toHaveBeenCalledOnce();
       });
+
+      it<SpaceTestContext>('emits a location event when a user leaves and when offlineTimeout passes', async ({
+        space,
+      }) => {
+        const spy = vi.spyOn(space.locations, 'emit');
+
+        // These share the same connection/client ids
+        createPresenceEvent(space, 'enter');
+
+        // Simulate a "set" location for a user
+        space.locations['onPresenceUpdate'](createPresenceMessage('update', { data: { location: '1' } }));
+
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        // We need to mock the message for both space & locations
+        const msg = createPresenceMessage('leave', { data: { location: '1' } });
+        space['onPresenceUpdate'](msg);
+        space.locations['onPresenceUpdate'](msg);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+
+        vi.advanceTimersByTime(130_000);
+
+        expect(spy).toHaveBeenCalledTimes(3);
+      });
     });
   });
 

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -105,9 +105,18 @@ class Space extends EventEmitter<SpaceEventsMap> {
   private addLeaver(message: Types.PresenceMessage) {
     const timeoutCallback = () => {
       const member = this.getMemberFromConnection(message.connectionId);
+
       this.emit('leave', member);
       this.removeMember(message.clientId);
       this.emit('membersUpdate', this.members);
+
+      if (member?.location) {
+        this.locations.emit('locationUpdate', {
+          previousLocation: member.location,
+          currentLocation: null,
+          member: { ...member, location: null },
+        });
+      }
     };
 
     this.leavers.push({


### PR DESCRIPTION
This emits an extra event when updating the local copy of members after an `offlineTimeout` passes.