### PR TITLE
docs: Add Component Locking section to README

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write --ignore-path .gitignore src demo",
     "format:check": "prettier --check --ignore-path .gitignore src demo",
     "test": "vitest run",
-    "watch": "vitest watch",
+    "test:watch": "vitest watch",
     "coverage": "vitest run --coverage",
     "build": "npm run build:mjs && npm run build:cjs && npm run build:iife",
     "build:mjs": "npx tsc --project tsconfig.mjs.json && cp res/package.mjs.json dist/mjs/package.json",


### PR DESCRIPTION
This adds a Component Locking section to the README inline with the description from the PR which introduced the feature (https://github.com/ably-labs/spaces/pull/102).

The documentation is intentionally light on context and is subject to change over the coming weeks as we iterate on the feature.