### PR TITLE
refactor: avoid early initialisation of common errors

### DIFF
--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -50,7 +50,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     const self = await this.space.members.getSelf();
 
     if (!self) {
-      throw ERR_NOT_ENTERED_SPACE;
+      throw ERR_NOT_ENTERED_SPACE();
     }
 
     const channel = this.getChannel();

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -21,38 +21,44 @@ export class ErrorInfo extends Error {
   }
 }
 
-export const ERR_SPACE_NAME_MISSING = new ErrorInfo({
-  message: 'must have a non-empty name for the space',
-  code: 101000,
-  statusCode: 400,
-});
+export const ERR_SPACE_NAME_MISSING = () =>
+  new ErrorInfo({
+    message: 'must have a non-empty name for the space',
+    code: 101000,
+    statusCode: 400,
+  });
 
-export const ERR_NOT_ENTERED_SPACE = new ErrorInfo({
-  message: 'must enter a space to perform this operation',
-  code: 101001,
-  statusCode: 400,
-});
+export const ERR_NOT_ENTERED_SPACE = () =>
+  new ErrorInfo({
+    message: 'must enter a space to perform this operation',
+    code: 101001,
+    statusCode: 400,
+  });
 
-export const ERR_LOCK_REQUEST_EXISTS = new ErrorInfo({
-  message: 'lock request already exists',
-  code: 101002,
-  statusCode: 400,
-});
+export const ERR_LOCK_REQUEST_EXISTS = () =>
+  new ErrorInfo({
+    message: 'lock request already exists',
+    code: 101002,
+    statusCode: 400,
+  });
 
-export const ERR_LOCK_IS_LOCKED = new ErrorInfo({
-  message: 'lock is currently locked',
-  code: 101003,
-  statusCode: 400,
-});
+export const ERR_LOCK_IS_LOCKED = () =>
+  new ErrorInfo({
+    message: 'lock is currently locked',
+    code: 101003,
+    statusCode: 400,
+  });
 
-export const ERR_LOCK_INVALIDATED = new ErrorInfo({
-  message: 'lock was invalidated by a concurrent lock request which now holds the lock',
-  code: 101004,
-  statusCode: 400,
-});
+export const ERR_LOCK_INVALIDATED = () =>
+  new ErrorInfo({
+    message: 'lock was invalidated by a concurrent lock request which now holds the lock',
+    code: 101004,
+    statusCode: 400,
+  });
 
-export const ERR_LOCK_RELEASED = new ErrorInfo({
-  message: 'lock was released',
-  code: 101005,
-  statusCode: 400,
-});
+export const ERR_LOCK_RELEASED = () =>
+  new ErrorInfo({
+    message: 'lock was released',
+    code: 101005,
+    statusCode: 400,
+  });

--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -58,7 +58,7 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
     const self = await this.space.members.getSelf();
 
     if (!self) {
-      throw ERR_NOT_ENTERED_SPACE;
+      throw ERR_NOT_ENTERED_SPACE();
     }
 
     const update: PresenceMember['data'] = {

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -94,14 +94,14 @@ export default class Locks extends EventEmitter<LockEventMap> {
   async acquire(id: string, opts?: LockOptions): Promise<Lock> {
     const self = await this.space.members.getSelf();
     if (!self) {
-      throw ERR_NOT_ENTERED_SPACE;
+      throw ERR_NOT_ENTERED_SPACE();
     }
 
     // check there isn't an existing PENDING or LOCKED request for the current
     // member, since we do not support nested locks
     let lock = this.getLock(id, self.connectionId);
     if (lock && lock.status !== 'unlocked') {
-      throw ERR_LOCK_REQUEST_EXISTS;
+      throw ERR_LOCK_REQUEST_EXISTS();
     }
 
     // initialise a new PENDING request
@@ -127,7 +127,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
   async release(id: string): Promise<void> {
     const self = await this.space.members.getSelf();
     if (!self) {
-      throw ERR_NOT_ENTERED_SPACE;
+      throw ERR_NOT_ENTERED_SPACE();
     }
 
     this.deleteLock(id, self.connectionId);
@@ -181,7 +181,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
 
         if (lock) {
           lock.status = 'unlocked';
-          lock.reason = ERR_LOCK_RELEASED;
+          lock.reason = ERR_LOCK_RELEASED();
           locks.delete(member.connectionId);
           this.emit('update', lock);
         }
@@ -216,7 +216,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
 
       if (!message.extras.locks.some((l: Lock) => l.id === lock.id)) {
         lock.status = 'unlocked';
-        lock.reason = ERR_LOCK_RELEASED;
+        lock.reason = ERR_LOCK_RELEASED();
         locks.delete(member.connectionId);
         this.emit('update', lock);
       }
@@ -262,7 +262,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
     ) {
       pendingLock.status = 'locked';
       lock.status = 'unlocked';
-      lock.reason = ERR_LOCK_INVALIDATED;
+      lock.reason = ERR_LOCK_INVALIDATED();
       this.emit('update', lock);
       return;
     }
@@ -270,7 +270,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
     // the lock is LOCKED and the PENDING request did not invalidate it, so
     // mark the PENDING request as UNLOCKED with a reason.
     pendingLock.status = 'unlocked';
-    pendingLock.reason = ERR_LOCK_IS_LOCKED;
+    pendingLock.reason = ERR_LOCK_IS_LOCKED();
   }
 
   updatePresence(member: SpaceMember) {

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -172,7 +172,7 @@ class Space extends EventEmitter<SpaceEventsMap> {
     const self = await this.members.getSelf();
 
     if (!self) {
-      throw ERR_NOT_ENTERED_SPACE;
+      throw ERR_NOT_ENTERED_SPACE();
     }
 
     const update = {

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -33,7 +33,7 @@ class Spaces {
 
   async get(name: string, options?: Subset<SpaceOptions>): Promise<Space> {
     if (typeof name !== 'string' || name.length === 0) {
-      throw ERR_SPACE_NAME_MISSING;
+      throw ERR_SPACE_NAME_MISSING();
     }
 
     if (this.spaces[name]) return this.spaces[name];


### PR DESCRIPTION
JavaScript stack straces are created upon initialisation of the `Error` object, so when errors are initialised ahead of the time they are thrown, the stack trace will not show the context of where/why the error was thrown, only the context of how the `Errors.ts` module was first loaded.

We used to do the same thing in ably-js until someone pointed out that they were getting misleading stack traces, see: 
- [Issue raised by third party](https://github.com/ably/ably-js/issues/1202)
- and [PR to fix it](https://github.com/ably/ably-js/pull/1206)