### PR TITLE
fix: unlock update hasn't triggered after lock release

### DIFF
--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { AblyProvider } from '@ably-labs/react-hooks';
 import App from './App';
 import './index.css';
 
-import { ably, SpaceContextProvider } from './components';
+import { SpaceContextProvider } from './components';
 import { SlidesStateContextProvider } from './components/SlidesStateContext.tsx';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
@@ -12,11 +11,9 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <SpaceContextProvider>
-      <AblyProvider client={ably}>
-        <SlidesStateContextProvider>
-          <App />
-        </SlidesStateContextProvider>
-      </AblyProvider>
+      <SlidesStateContextProvider>
+        <App />
+      </SlidesStateContextProvider>
     </SpaceContextProvider>
   </React.StrictMode>,
 );

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -55,10 +55,3 @@ export const ERR_LOCK_INVALIDATED = () =>
     code: 101004,
     statusCode: 400,
   });
-
-export const ERR_LOCK_RELEASED = () =>
-  new ErrorInfo({
-    message: 'lock was released',
-    code: 101005,
-    statusCode: 400,
-  });

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -130,7 +130,12 @@ export default class Locks extends EventEmitter<LockEventMap> {
       throw ERR_NOT_ENTERED_SPACE();
     }
 
+    const lock = this.locks.get(id)?.get(self.connectionId);
     this.deleteLock(id, self.connectionId);
+    if (lock) {
+      lock.status = 'unlocked';
+      this.emit('update', lock);
+    }
 
     await this.updatePresence(self);
   }

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -36,11 +36,11 @@ class Spaces {
       throw ERR_SPACE_NAME_MISSING();
     }
 
-    if (this.spaces[name]) return this.spaces[name];
-
     if (this.connection.state !== 'connected') {
       await this.connection.once('connected');
     }
+
+    if (this.spaces[name]) return this.spaces[name];
 
     const space = new Space(name, this.client, options);
     this.spaces[name] = space;


### PR DESCRIPTION
Unlock update hasn't triggered after lock release

Added emitting `'update'` event after lock released 

---

**Update:** I've updated this to a different fix. When you `get` a lock, it's not valuable to get `unlocked` locks - these are only useful in listeners. So the change here, which fixes the above bug, is to make sure we clear any unlocked locks, but send them in presence to process. After processing, the lock is clear. This makes the logic to compare if an event should be fired work (otherwise the mutated state is equal to the processed state and nothing happens locally).