### PR TITLE
cursors: Fix cursor batching calculation

### DIFF
--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -116,7 +116,7 @@ describe('Cursors', () => {
       vi.spyOn(channel.presence, 'get').mockImplementation(createPresenceCount(2));
       await cursors['onPresenceUpdate']();
       expect(batching.shouldSend).toBeTruthy();
-      expect(batching.batchTime).toEqual(100);
+      expect(batching.batchTime).toEqual(200);
     });
 
     it<CursorsTestContext>('batchTime is updated when multiple people are present', async ({
@@ -126,7 +126,7 @@ describe('Cursors', () => {
     }) => {
       vi.spyOn(channel.presence, 'get').mockImplementation(createPresenceCount(2));
       await cursors['onPresenceUpdate']();
-      expect(batching.batchTime).toEqual(100);
+      expect(batching.batchTime).toEqual(200);
     });
 
     describe('pushCursorPosition', () => {

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -76,7 +76,7 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     const channel = this.getChannel();
     const cursorsMembers = await channel.presence.get();
     this.cursorBatching.setShouldSend(cursorsMembers.length > 1);
-    this.cursorBatching.setBatchTime((cursorsMembers.length - 1) * this.options.outboundBatchInterval);
+    this.cursorBatching.setBatchTime(cursorsMembers.length * this.options.outboundBatchInterval);
   }
 
   private isUnsubscribed() {


### PR DESCRIPTION
The cursor batching algorithm was designed so that the overall channel message rate remains lower than an upper bound limit, and the algorithm expects the batching to multiply the batch interval by the number of members, not the number of members minus one as we're currently doing.