### PR TITLE
Refactor space updates

### DIFF
--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -153,10 +153,28 @@ describe('Space', () => {
         presenceMap,
         space,
       }) => {
-        presenceMap.set('1', createPresenceMessage('enter'));
+        presenceMap.set(
+          '1',
+          createPresenceMessage('enter', {
+            data: {
+              profileUpdate: {
+                id: 1,
+                current: { color: 'black' },
+              },
+              locationUpdate: {
+                id: null,
+                current: null,
+                previous: null,
+              },
+            },
+          }),
+        );
         const updateSpy = vi.spyOn(presence, 'update');
         await space.updateProfileData((profileData) => ({ ...profileData, name: 'Betty' }));
-        expect(updateSpy).toHaveBeenNthCalledWith(1, createProfileUpdate({ current: { name: 'Betty' } }));
+        expect(updateSpy).toHaveBeenNthCalledWith(
+          1,
+          createProfileUpdate({ current: { name: 'Betty', color: 'black' } }),
+        );
       });
     });
 

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -192,13 +192,94 @@ describe('Space', () => {
   });
 
   describe('leave', () => {
-    it<SpaceTestContext>('leaves a space successfully', async ({ presence, presenceMap, space }) => {
-      presenceMap.set('1', createPresenceMessage('enter'));
+    it<SpaceTestContext>('leaves a space successfully and does not nullify presence data', async ({
+      presence,
+      presenceMap,
+      space,
+    }) => {
+      presenceMap.set(
+        '1',
+        createPresenceMessage('enter', {
+          data: {
+            profileUpdate: { id: 1, current: { name: 'Betty' } },
+            locationUpdate: { id: null, current: { slide: 1 }, previous: null },
+          },
+        }),
+      );
 
-      await space.enter();
       const spy = vi.spyOn(presence, 'leave');
       await space.leave();
-      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenNthCalledWith(1, {
+        profileUpdate: {
+          id: null,
+          current: { name: 'Betty' },
+        },
+        locationUpdate: {
+          id: null,
+          current: { slide: 1 },
+          previous: null,
+        },
+      });
+    });
+
+    it<SpaceTestContext>('leaves a space successfully and nullifies presence data', async ({
+      presence,
+      presenceMap,
+      space,
+    }) => {
+      presenceMap.set(
+        '1',
+        createPresenceMessage('enter', {
+          data: {
+            profileUpdate: { id: 1, current: { name: 'Betty' } },
+            locationUpdate: { id: null, current: { slide: 1 }, previous: null },
+          },
+        }),
+      );
+
+      const spy = vi.spyOn(presence, 'leave');
+      await space.leave(null);
+      expect(spy).toHaveBeenNthCalledWith(1, {
+        profileUpdate: {
+          id: 'NanoidID',
+          current: null,
+        },
+        locationUpdate: {
+          id: null,
+          current: { slide: 1 },
+          previous: null,
+        },
+      });
+    });
+
+    it<SpaceTestContext>('leaves a space successfully and updates presence data', async ({
+      presence,
+      presenceMap,
+      space,
+    }) => {
+      presenceMap.set(
+        '1',
+        createPresenceMessage('enter', {
+          data: {
+            profileUpdate: { id: 1, current: { name: 'Betty' } },
+            locationUpdate: { id: null, current: { slide: 1 }, previous: null },
+          },
+        }),
+      );
+
+      const spy = vi.spyOn(presence, 'leave');
+      await space.leave({ colorWhenLeft: 'blue' });
+      expect(spy).toHaveBeenNthCalledWith(1, {
+        profileUpdate: {
+          id: 'NanoidID',
+          current: { colorWhenLeft: 'blue' },
+        },
+        locationUpdate: {
+          id: null,
+          current: { slide: 1 },
+          previous: null,
+        },
+      });
     });
   });
 

--- a/src/SpaceUpdate.test.ts
+++ b/src/SpaceUpdate.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, vi, expect } from 'vitest';
+
+import SpaceUpdate from './SpaceUpdate.js';
+import { createSpaceMember } from './utilities/test/fakes.js';
+
+vi.mock('nanoid');
+
+describe('SpaceUpdate', () => {
+  it('creates a profileUpdate', () => {
+    const self = createSpaceMember({ profileData: { name: 'Berry' } });
+    const update = new SpaceUpdate({ self });
+    expect(update.updateProfileData({ name: 'Barry' })).toEqual({
+      data: {
+        locationUpdate: {
+          current: null,
+          id: null,
+          previous: null,
+        },
+        profileUpdate: {
+          current: {
+            name: 'Barry',
+          },
+          id: 'NanoidID',
+        },
+      },
+      extras: undefined,
+    });
+  });
+
+  it('creates a locationUpdate', () => {
+    const self = createSpaceMember({ location: { slide: 3 }, profileData: { name: 'Berry' } });
+    const update = new SpaceUpdate({ self });
+    expect(update.updateLocation({ slide: 1 }, null)).toEqual({
+      data: {
+        locationUpdate: {
+          current: { slide: 1 },
+          id: 'NanoidID',
+          previous: { slide: 3 },
+        },
+        profileUpdate: {
+          current: {
+            name: 'Berry',
+          },
+          id: null,
+        },
+      },
+      extras: undefined,
+    });
+  });
+
+  it('creates an object with no updates to current data', () => {
+    const self = createSpaceMember({ location: { slide: 3 }, profileData: { name: 'Berry' } });
+    const update = new SpaceUpdate({ self });
+    expect(update.noop()).toEqual({
+      data: {
+        locationUpdate: {
+          current: { slide: 3 },
+          id: null,
+          previous: null,
+        },
+        profileUpdate: {
+          current: {
+            name: 'Berry',
+          },
+          id: null,
+        },
+      },
+      extras: undefined,
+    });
+  });
+});

--- a/src/SpaceUpdate.ts
+++ b/src/SpaceUpdate.ts
@@ -1,0 +1,73 @@
+import { nanoid } from 'nanoid';
+import { Types } from 'ably';
+
+import type { SpaceMember, ProfileData } from './types.js';
+import type { PresenceMember } from './utilities/types.js';
+
+export interface SpacePresenceData {
+  data: PresenceMember['data'];
+  extras: PresenceMember['extras'];
+}
+
+class SpaceUpdate {
+  private self: SpaceMember | null;
+  private extras: Types.PresenceMessage['extras'];
+
+  constructor({ self, extras }: { self: SpaceMember | null; extras?: Types.PresenceMessage['extras'] }) {
+    this.self = self;
+    this.extras = extras;
+  }
+
+  private profileUpdate(id: string | null, current: ProfileData) {
+    return { id, current };
+  }
+
+  private profileNoChange() {
+    return this.profileUpdate(null, this.self ? this.self.profileData : null);
+  }
+
+  private locationUpdate(id: string | null, current: SpaceMember['location'], previous: SpaceMember['location']) {
+    return { id, current, previous };
+  }
+
+  private locationNoChange() {
+    const location = this.self ? this.self.location : null;
+    return this.locationUpdate(null, location, null);
+  }
+
+  updateProfileData(current: ProfileData): SpacePresenceData {
+    return {
+      data: {
+        profileUpdate: this.profileUpdate(nanoid(), current),
+        locationUpdate: this.locationNoChange(),
+      },
+      extras: this.extras,
+    };
+  }
+
+  updateLocation(location: SpaceMember['location'], previousLocation?: SpaceMember['location']): SpacePresenceData {
+    return {
+      data: {
+        profileUpdate: this.profileNoChange(),
+        locationUpdate: this.locationUpdate(
+          nanoid(),
+          location,
+          previousLocation ? previousLocation : this.self?.location,
+        ),
+      },
+      extras: this.extras,
+    };
+  }
+
+  noop(): SpacePresenceData {
+    return {
+      data: {
+        profileUpdate: this.profileNoChange(),
+        locationUpdate: this.locationNoChange(),
+      },
+      extras: this.extras,
+    };
+  }
+}
+
+export default SpaceUpdate;


### PR DESCRIPTION
This refactors space updates so we have a single class responsible for managing the shape of the updates.

This also fixes:
- `updateProfileData` not passing an argument to the update function (see @snikidev 's report)
- `.leave` resetting profileData for users when no arguments are passed in https://ably.atlassian.net/browse/MMB-303