### PR TITLE
Silence Vite warnings about node packages loaded by postcss

### DIFF
--- a/demo/noop.js
+++ b/demo/noop.js
@@ -1,0 +1,2 @@
+// See https://github.com/vitejs/vite/issues/9200
+module.exports = {};

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -3,6 +3,16 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Silence Vite warnings about node packages loaded by postcss
+      // See https://github.com/vitejs/vite/issues/9200
+      path: './noop.js',
+      fs: './noop.js',
+      url: './noop.js',
+      'source-map-js': './noop.js',
+    },
+  },
   plugins: [react()],
   server: {
     port: 8080,


### PR DESCRIPTION
See https://github.com/vitejs/vite/issues/9200 (this is only happening in dev mode)