### PR TITLE
Remove unused export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@ import Spaces from './Spaces.js';
 
 export type Space = Awaited<ReturnType<Spaces['get']>>;
 
-// Can be changed to * when we update to TS5
-
+// Note: this should be the only non-type export from this file,
+// otherwise the rollup IIFE build will export an object instead of a constructor
 export default Spaces;
 
+// Can be changed to * when we update to TS5
 export type {
   CursorsOptions,
   CursorPosition,
@@ -17,5 +18,3 @@ export type {
   Lock,
   LockStatus,
 } from './types.js';
-
-export { LockAttributes } from './Locks.js';


### PR DESCRIPTION
This unused export would make rollup create an object instead of a constructor for the IIFE bundle.