### PR TITLE
Make `Locks.prototype.getLocksForConnectionId` private

### DIFF
--- a/demo/src/hooks/useElementSelect.ts
+++ b/demo/src/hooks/useElementSelect.ts
@@ -42,7 +42,7 @@ export const useClickOutside = (ref: MutableRefObject<HTMLElement | null>, self?
         await space.locations.set({ slide: self.location?.slide, element: undefined });
         // TODO delete this workaround when spaces API is ready
         await delay(60);
-        await releaseMyLocks(space, self);
+        await releaseMyLocks(space);
       }
     };
 

--- a/demo/src/utils/locking.ts
+++ b/demo/src/utils/locking.ts
@@ -1,10 +1,7 @@
 import { Space } from '@ably/spaces';
-import { Member } from './types';
 
-export const releaseMyLocks = async (space: Space, self: Member) => {
-  await Promise.all([
-    ...space.locks.getLocksForConnectionId(self.connectionId).map((lock) => space.locks.release(lock.id)),
-  ]);
+export const releaseMyLocks = async (space: Space) => {
+  await Promise.all([...space.locks.getSelf().map((lock) => space.locks.release(lock.id))]);
 };
 
 export const buildLockId = (slide: string | undefined, element: string | undefined) =>

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -292,7 +292,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
     return locks.delete(connectionId);
   }
 
-  getLocksForConnectionId(connectionId: string): Lock[] {
+  private getLocksForConnectionId(connectionId: string): Lock[] {
     const requests: Lock[] = [];
 
     for (const locks of this.locks.values()) {


### PR DESCRIPTION
Whilst working on MMB-156 I asked whether this was meant to be part of the public API and was told no, and that its usage should be replaced by `Locks.prototype.getSelf`.

I have no idea whether the `delay(60)` preceding the call to `releaseMyLocks` in the `useElementSelect` hook is still necessary, since I don’t know what the "spaces API" that it refers to is.