### PR TITLE
Revert "Remove unused export"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,10 @@ import Spaces from './Spaces.js';
 
 export type Space = Awaited<ReturnType<Spaces['get']>>;
 
-// Note: this should be the only non-type export from this file,
-// otherwise the rollup IIFE build will export an object instead of a constructor
+// Can be changed to * when we update to TS5
+
 export default Spaces;
 
-// Can be changed to * when we update to TS5
 export type {
   CursorsOptions,
   CursorPosition,
@@ -18,3 +17,5 @@ export type {
   Lock,
   LockStatus,
 } from './types.js';
+
+export { LockAttributes } from './Locks.js';


### PR DESCRIPTION
This reverts commit b882b4a44191de91d5e424ede7ccd9d7f3a3af63.

Although this fixes our CDN build, `LockAttributes` can't be removed as that would make them unavailable in the public API.

Reverting so we can release and work on a proper fix for both issues.