### PR TITLE
Demo updates

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@ably-labs/react-hooks": "^3.0.0-canary.1",
-        "@ably/spaces": "^0.1.0",
+        "@ably/spaces": "0.1.3",
         "ably": "^1.2.43",
         "classnames": "^2.3.2",
         "dayjs": "^1.11.9",
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@ably/spaces": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ably/spaces/-/spaces-0.1.0.tgz",
-      "integrity": "sha512-NryakCmQW1nsGtlkJzuKirC2xhfb3uaB6RheImjo9vC0cwAmwK+yYzoCBWtfUVbBKdYeOae1YE6DKC9zumnqeA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ably/spaces/-/spaces-0.1.3.tgz",
+      "integrity": "sha512-8egeUAvl+L6wrBuIIVx17BdQH+bl9rP0VRqEuYpx8+lRt8pQS+t/gyfjE3XQbg5OIaILbeiDbhgkNNDD7OOlRw==",
       "dependencies": {
         "nanoid": "^4.0.2"
       },
@@ -20409,9 +20409,9 @@
       }
     },
     "@ably/spaces": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ably/spaces/-/spaces-0.1.0.tgz",
-      "integrity": "sha512-NryakCmQW1nsGtlkJzuKirC2xhfb3uaB6RheImjo9vC0cwAmwK+yYzoCBWtfUVbBKdYeOae1YE6DKC9zumnqeA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ably/spaces/-/spaces-0.1.3.tgz",
+      "integrity": "sha512-8egeUAvl+L6wrBuIIVx17BdQH+bl9rP0VRqEuYpx8+lRt8pQS+t/gyfjE3XQbg5OIaILbeiDbhgkNNDD7OOlRw==",
       "requires": {
         "nanoid": "^4.0.2"
       }

--- a/demo/package.json
+++ b/demo/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@ably-labs/react-hooks": "^3.0.0-canary.1",
-    "@ably/spaces": "^0.1.0",
-    "ably": "^1.2.43",
+    "@ably/spaces": "0.1.3",
+    "ably": "^1.2.44",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.9",
     "nanoid": "^4.0.2",

--- a/demo/src/utils/locking.ts
+++ b/demo/src/utils/locking.ts
@@ -1,7 +1,11 @@
 import { Space } from '@ably/spaces';
 
 export const releaseMyLocks = async (space: Space) => {
-  await Promise.all([...space.locks.getSelf().map((lock) => space.locks.release(lock.id))]);
+  const locks = await space.locks.getSelf();
+
+  if (locks.length > 0) {
+    locks.forEach((lock) => space.locks.release(lock.id));
+  }
 };
 
 export const buildLockId = (slide: string | undefined, element: string | undefined) =>


### PR DESCRIPTION
- updates the ably/spaces version used to 0.1.3
- fixes the "release all locks" method in demo (it would't work because `getSelf` is async)