### PR TITLE
Remove Husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run format:check
-
-npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsdoc": "^46.7.0",
         "eslint-plugin-security": "^1.7.1",
-        "husky": "^8.0.0",
         "prettier": "^2.8.3",
         "rollup": "^3.28.0",
         "ts-node": "^10.9.1",
@@ -2889,21 +2888,6 @@
       },
       "engines": {
         "node": ">=10.19.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -7150,12 +7134,6 @@
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
       }
-    },
-    "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true
     },
     "ignore": {
       "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "build:mjs": "npx tsc --project tsconfig.mjs.json && cp res/package.mjs.json dist/mjs/package.json",
     "build:cjs": "npx tsc --project tsconfig.cjs.json && cp res/package.cjs.json dist/cjs/package.json",
     "build:iife": "rm -rf dist/iife && npx tsc --project tsconfig.iife.json && rollup -c",
-    "prepare": "husky install",
     "examples:locks": "ts-node ./examples/locks.ts"
   },
   "exports": {
@@ -49,7 +48,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^46.7.0",
     "eslint-plugin-security": "^1.7.1",
-    "husky": "^8.0.0",
     "prettier": "^2.8.3",
     "rollup": "^3.28.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Whilst I am a strong believer in making sure that each commit conforms to formatting rules and that its tests pass, I have found that the downsides of using Husky to enforce this outweigh the benefits.

In particular, I have my own set of personal Git hooks that I use as part of my development workflow, and have configured my global `core.hooksPath` so that they are applied across all repositories that I work with. However, when I run `npm install` inside this repo, Husky then comes along and — without even giving me a warning that it’s going to do so — sets the repo’s local `core.hooksPath` to its own value, silently disabling my personal hooks.

As far as I can tell, there is no way for Husky to nicely co-exist with personal Git hooks. With this in mind, I would prefer we remove Husky and leave it up to developers to find their own way of checking their commits.

(I would also be happy to, alternatively, keep the Husky config but remove it from the `prepare` NPM script, leaving developers with the option of running `husky install` if they wish.)