### PR TITLE
[MMB-317], [MMB-318] — Remove the `LockAttributes` type

### DIFF
--- a/docs/class-definitions.md
+++ b/docs/class-definitions.md
@@ -706,5 +706,5 @@ type LockStatus = 'pending' | 'locked' | 'unlocked';
 Additional attributes that can be set when acquiring a lock.
 
 ```ts
-type LockAttributes = Map<string, string>;
+type LockAttributes = Record<string, unknown>;
 ```

--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -3,7 +3,6 @@ import { Realtime, Types } from 'ably/promises';
 
 import Space from './Space.js';
 import type { SpaceMember, LockStatus } from './types.js';
-import { LockAttributes } from './Locks.js';
 import { createPresenceMessage } from './utilities/test/fakes.js';
 
 interface SpaceTestContext {
@@ -77,9 +76,7 @@ describe('Locks', () => {
       const presenceUpdate = vi.spyOn(presence, 'update');
 
       const lockID = 'test';
-      const attributes = new LockAttributes();
-      attributes.set('key1', 'foo');
-      attributes.set('key2', 'bar');
+      const attributes = { key1: 'foo', key2: 'bar' };
       const req = await space.locks.acquire(lockID, { attributes });
       expect(req.attributes).toBe(attributes);
 

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -13,11 +13,7 @@ import EventEmitter, {
 
 import SpaceUpdate from './SpaceUpdate.js';
 
-export class LockAttributes extends Map<string, string> {
-  toJSON() {
-    return Object.fromEntries(this);
-  }
-}
+export type LockAttributes = Record<string, unknown>;
 
 interface LockOptions {
   attributes: LockAttributes;
@@ -203,6 +199,7 @@ export default class Locks extends EventEmitter<LockEventMap> {
         this.emit('update', { ...lock, member });
       }
 
+      // TODO this lock that comes from the PresenceMessage has no type checking
       this.setLock({ ...lock, member });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,4 @@ export type {
   LockStatus,
 } from './types.js';
 
-export { LockAttributes } from './Locks.js';
+export type { LockAttributes } from './Locks.js';


### PR DESCRIPTION
Resolves [MMB-317](https://ably.atlassian.net/browse/MMB-317) and [MMB-318](https://ably.atlassian.net/browse/MMB-318).

I have chosen to simply remove the `LockAttributes` class and replace it with `Record<string, unknown>`, which is what we use elsewhere for representing arbitrary key-value pairs in the public API of the SDK.

See https://github.com/ably/docs/pull/2023 for corresponding documentation update.

[MMB-317]: https://ably.atlassian.net/browse/MMB-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMB-318]: https://ably.atlassian.net/browse/MMB-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ