### PR TITLE
[COL-333] Return value of a lock not it's reference

### DIFF
--- a/src/Locks.test.ts
+++ b/src/Locks.test.ts
@@ -380,6 +380,22 @@ describe('Locks', () => {
       expect(lock3).toBeDefined();
     });
 
+    it<SpaceTestContext>('returns the lock by value, not reference', ({ space }) => {
+      const lockGet1 = space.locks.get('lock1');
+      const lockGet2 = space.locks.get('lock1');
+      expect(lockGet1).toEqual(expect.objectContaining({ status: 'locked' }));
+      // Note we are using toBe here on purpose, to check the reference, not value
+      expect(lockGet1).not.toBe(lockGet2);
+    });
+
+    it<SpaceTestContext>('returns locks by value, not reference', async ({ space }) => {
+      const lockGetAll1 = await space.locks.getAll();
+      const lockGetAll2 = await space.locks.getAll();
+      expect(lockGetAll1).toEqual(expect.arrayContaining([expect.objectContaining({ status: 'locked' })]));
+      // Note we are using toBe here on purpose, to check the reference, not value
+      expect(lockGetAll1[0]).not.toBe(lockGetAll2[0]);
+    });
+
     describe('getSelf', () => {
       it<SpaceTestContext>('returns all locks in the LOCKED state that belong to self', async ({ space }) => {
         const member1 = await space.members.getByConnectionId('1')!;
@@ -397,6 +413,13 @@ describe('Locks', () => {
               throw new Error(`unexpected lock id: ${lock.id}`);
           }
         }
+      });
+
+      it<SpaceTestContext>('returns locks by value not reference', async ({ space }) => {
+        const locksGetSelf1 = await space.locks.getSelf();
+        const locksGetSelf2 = await space.locks.getSelf();
+        // Note we are using toBe here on purpose, to check the reference, not value
+        expect(locksGetSelf1[0]).not.toBe(locksGetSelf2[0]);
       });
     });
 


### PR DESCRIPTION
https://ably.atlassian.net/browse/COL-333

When a lock is retrieved by using locks.get, a reference to an object is returned. By mutating this reference, a developer, could in theory, mutate the lock held by Spaces. This could lead to subtle and hard to debug issues.

This commit changes the .get and .getAll methods to return copies of objects instead. This breaks some of the internal mutations, so they are replaced by the already present .setLock method which will override the lock with a new object, severing any dependecies on references.