### PR TITLE
feat: move events to `options`

### DIFF
--- a/demo/src/components/Cursors.tsx
+++ b/demo/src/components/Cursors.tsx
@@ -4,7 +4,7 @@ import { CursorSvg } from '.';
 import { CURSOR_LEAVE } from '../hooks';
 
 export const Cursors = () => {
-  const { space, cursors } = useCursors(undefined, { returnCursors: true });
+  const { space, cursors } = useCursors({ returnCursors: true });
 
   const activeCursors = Object.keys(cursors)
     .filter((connectionId) => {

--- a/docs/react.md
+++ b/docs/react.md
@@ -81,29 +81,19 @@ useMembers((memberUpdate) => {
 });
 
 // Subscribe to member enter events only
-useMembers('enter', (memberJoined) => {
+useMembers((memberJoined) => {
   console.log(memberJoined);
-});
+}, { events: 'enter' });
 
 // Subscribe to member leave events only
-useMembers('leave', (memberLeft) => {
+useMembers((memberLeft) => {
   console.log(memberLeft);
-});
+}, { events: 'leave' });
 
-// Subscribe to member remove events only
-useMembers('remove', (memberRemoved) => {
+// Subscribe to updateProfile and remove events only
+useMembers((memberRemoved) => {
   console.log(memberRemoved);
-});
-
-// Subscribe to profile updates on members only
-useMembers('updateProfile', (memberProfileUpdated) => {
-  console.log(memberProfileUpdated);
-});
-
-// Subscribe to all updates to members
-useMembers('update', (memberUpdate) => {
-  console.log(memberUpdate);
-});
+}, { events: ['remove', 'updateProfile'] });
 ```
 
 ### useLocation

--- a/src/react/useLocations.ts
+++ b/src/react/useLocations.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef } from 'react';
 import { SpaceContext } from './contexts/SpaceContext.js';
-import { isArray, isFunction, isString } from '../utilities/is.js';
+import { isFunction } from '../utilities/is.js';
 
 import type Locations from '../Locations.js';
 import type { SpaceMember } from '../types.js';
@@ -14,30 +14,20 @@ interface UseLocationsResult {
 
 type UseLocationCallback = (locationUpdate: { member: SpaceMember }) => void;
 
-export type LocationsEvent = 'update';
-
-function useLocations(callback?: UseLocationCallback, options?: UseSpaceOptions): UseLocationsResult;
-function useLocations(
-  event: LocationsEvent | LocationsEvent[],
-  callback: UseLocationCallback,
-  options?: UseSpaceOptions,
-): UseLocationsResult;
+function useLocations(options?: UseSpaceOptions): UseLocationsResult;
+function useLocations(callback: UseLocationCallback, options?: UseSpaceOptions): UseLocationsResult;
 
 /*
  * Registers a subscription on the `Space.locations` object
  */
 function useLocations(
-  eventOrCallback?: LocationsEvent | LocationsEvent[] | UseLocationCallback,
   callbackOrOptions?: UseLocationCallback | UseSpaceOptions,
   optionsOrNothing?: UseSpaceOptions,
 ): UseLocationsResult {
   const space = useContext(SpaceContext);
   const locations = space?.locations;
 
-  const callback =
-    isString(eventOrCallback) || isArray(eventOrCallback)
-      ? (callbackOrOptions as UseLocationCallback)
-      : eventOrCallback;
+  const callback = isFunction(callbackOrOptions) ? (callbackOrOptions as UseLocationCallback) : undefined;
 
   const options = isFunction(callbackOrOptions) ? optionsOrNothing : callbackOrOptions;
 
@@ -52,18 +42,10 @@ function useLocations(
       const listener: UseLocationCallback = (params) => {
         callbackRef.current?.(params);
       };
-      if (isString(eventOrCallback)) {
-        locations.subscribe(eventOrCallback, listener);
-      } else {
-        locations.subscribe(listener);
-      }
+      locations.subscribe(listener);
 
       return () => {
-        if (isString(eventOrCallback)) {
-          locations.unsubscribe(eventOrCallback, listener);
-        } else {
-          locations.unsubscribe(listener);
-        }
+        locations.unsubscribe(listener);
       };
     }
   }, [locations, options?.skip]);

--- a/src/react/useLocks.ts
+++ b/src/react/useLocks.ts
@@ -1,9 +1,8 @@
 import { useEffect, useRef } from 'react';
-import { isArray, isFunction, isString } from '../utilities/is.js';
+import { isFunction } from '../utilities/is.js';
 import { useSpace, type UseSpaceResult } from './useSpace.js';
 
 import type { EventKey } from '../utilities/EventEmitter.js';
-import type { UseSpaceOptions } from './types.js';
 import type { LockEventMap } from '../Locks.js';
 import type { Lock } from '../types.js';
 
@@ -11,25 +10,32 @@ type LocksEvent = EventKey<LockEventMap>;
 
 type UseLocksCallback = (params: Lock) => void;
 
+export interface UseLocksOptions {
+  /**
+   * If specified, callback will be invoked only for this events
+   */
+  events?: LocksEvent | LocksEvent[];
+  /**
+   * Skip parameter makes the hook skip execution -
+   * this is useful in order to conditionally register a subscription to
+   * an EventListener (needed because it's not possible to conditionally call a hook in react)
+   */
+  skip?: boolean;
+}
+
 /*
  * Registers a subscription on the `Space.locks` object
  */
-function useLocks(callback?: UseLocksCallback, options?: UseSpaceOptions): UseSpaceResult;
+function useLocks(options?: UseLocksOptions): UseSpaceResult;
+function useLocks(callback: UseLocksCallback, options?: UseLocksOptions): UseSpaceResult;
 function useLocks(
-  event: LocksEvent | LocksEvent[],
-  callback: UseLocksCallback,
-  options?: UseSpaceOptions,
-): UseSpaceResult;
-function useLocks(
-  eventOrCallback?: LocksEvent | LocksEvent[] | UseLocksCallback,
-  callbackOrOptions?: UseLocksCallback | UseSpaceOptions,
-  optionsOrNothing?: UseSpaceOptions,
+  callbackOrOptions?: UseLocksCallback | UseLocksOptions,
+  optionsOrNothing?: UseLocksOptions,
 ): UseSpaceResult {
   const spaceContext = useSpace();
   const { space } = spaceContext;
 
-  const callback =
-    isString(eventOrCallback) || isArray(eventOrCallback) ? (callbackOrOptions as UseLocksCallback) : eventOrCallback;
+  const callback = isFunction(callbackOrOptions) ? callbackOrOptions : undefined;
 
   const options = isFunction(callbackOrOptions) ? optionsOrNothing : callbackOrOptions;
 
@@ -44,21 +50,21 @@ function useLocks(
       const listener: UseLocksCallback = (params) => {
         callbackRef.current?.(params);
       };
-      if (isString(eventOrCallback)) {
-        space?.locks.subscribe(eventOrCallback, listener);
+      if (options?.events) {
+        space?.locks.subscribe(options.events, listener);
       } else {
         space?.locks.subscribe<any>(listener);
       }
 
       return () => {
-        if (isString(eventOrCallback)) {
-          space?.locks.unsubscribe(eventOrCallback, listener);
+        if (options?.events) {
+          space?.locks.unsubscribe(options.events, listener);
         } else {
           space?.locks.unsubscribe<any>(listener);
         }
       };
     }
-  }, [space?.locks, options?.skip]);
+  }, [space?.locks, options?.skip, options?.events]);
 
   return spaceContext;
 }

--- a/src/react/useMembers.test.tsx
+++ b/src/react/useMembers.test.tsx
@@ -48,7 +48,7 @@ describe('useMembers', () => {
   }) => {
     const callbackSpy = vi.fn();
     // @ts-ignore
-    const { result } = renderHook(() => useMembers(['enter', 'update'], callbackSpy), {
+    const { result } = renderHook(() => useMembers(callbackSpy, { events: ['enter', 'update'] }), {
       wrapper: ({ children }) => (
         <SpacesProvider client={spaces}>
           <SpaceProvider name="spaces-test">{children}</SpaceProvider>


### PR DESCRIPTION
I believe events filter will be better to put into options. We will have less complicated overloaded type for hooks, and we already have `skip` option, that in some ways similar to events filter 