### PR TITLE
fix: `useLocations`,`useMembers` hook overload

### DIFF
--- a/demo/src/components/Cursors.tsx
+++ b/demo/src/components/Cursors.tsx
@@ -4,7 +4,7 @@ import { CursorSvg } from '.';
 import { CURSOR_LEAVE } from '../hooks';
 
 export const Cursors = () => {
-  const { space, cursors } = useCursors(undefined, { returnCursors: true });
+  const { space, cursors } = useCursors({ returnCursors: true });
 
   const activeCursors = Object.keys(cursors)
     .filter((connectionId) => {

--- a/src/react/useCursors.ts
+++ b/src/react/useCursors.ts
@@ -3,6 +3,7 @@ import { SpaceContext } from './contexts/SpaceContext.js';
 import { useMembers } from './useMembers.js';
 import { useChannelState } from './useChannelState.js';
 import { useConnectionState } from './useConnectionState.js';
+import { isFunction } from '../utilities/is.js';
 
 import type { CursorUpdate, SpaceMember } from '../types.js';
 import type { ErrorInfo } from 'ably';
@@ -33,7 +34,12 @@ type UseCursorsCallback = (params: CursorUpdate) => void;
 /**
  * Registers a subscription on the `Space.cursors` object
  */
-export function useCursors(callback?: UseCursorsCallback, options?: UseCursorsOptions): UseCursorsResult {
+function useCursors(options?: UseCursorsOptions): UseCursorsResult;
+function useCursors(callback: UseCursorsCallback, options?: UseCursorsOptions): UseCursorsResult;
+function useCursors(
+  callbackOrOptions?: UseCursorsCallback | UseCursorsOptions,
+  optionsOrNothing?: UseCursorsOptions,
+): UseCursorsResult {
   const space = useContext(SpaceContext);
   const [cursors, setCursors] = useState<Record<string, { member: SpaceMember; cursorUpdate: CursorUpdate }>>({});
   const { members } = useMembers();
@@ -46,6 +52,9 @@ export function useCursors(callback?: UseCursorsCallback, options?: UseCursorsOp
       return acc;
     }, {} as Record<string, SpaceMember>);
   }, [members]);
+
+  const callback = isFunction(callbackOrOptions) ? callbackOrOptions : undefined;
+  const options = isFunction(callbackOrOptions) ? optionsOrNothing : callbackOrOptions;
 
   const callbackRef = useRef<UseCursorsCallback | undefined>(callback);
   const optionsRef = useRef<UseCursorsOptions | undefined>(options);
@@ -86,3 +95,5 @@ export function useCursors(callback?: UseCursorsCallback, options?: UseCursorsOp
     cursors,
   };
 }
+
+export { useCursors };

--- a/src/react/useLocations.ts
+++ b/src/react/useLocations.ts
@@ -52,14 +52,14 @@ function useLocations(
       const listener: UseLocationCallback = (params) => {
         callbackRef.current?.(params);
       };
-      if (isString(eventOrCallback)) {
+      if (!isFunction(eventOrCallback)) {
         locations.subscribe(eventOrCallback, listener);
       } else {
         locations.subscribe(listener);
       }
 
       return () => {
-        if (isString(eventOrCallback)) {
+        if (!isFunction(eventOrCallback)) {
           locations.unsubscribe(eventOrCallback, listener);
         } else {
           locations.unsubscribe(listener);

--- a/src/react/useLocks.ts
+++ b/src/react/useLocks.ts
@@ -44,14 +44,14 @@ function useLocks(
       const listener: UseLocksCallback = (params) => {
         callbackRef.current?.(params);
       };
-      if (isString(eventOrCallback)) {
+      if (!isFunction(eventOrCallback)) {
         space?.locks.subscribe(eventOrCallback, listener);
       } else {
         space?.locks.subscribe<any>(listener);
       }
 
       return () => {
-        if (isString(eventOrCallback)) {
+        if (!isFunction(eventOrCallback)) {
           space?.locks.unsubscribe(eventOrCallback, listener);
         } else {
           space?.locks.unsubscribe<any>(listener);

--- a/src/react/useMembers.ts
+++ b/src/react/useMembers.ts
@@ -63,14 +63,14 @@ function useMembers(
       const listener: UseMembersCallback = (params) => {
         callbackRef.current?.(params);
       };
-      if (isString(eventOrCallback)) {
+      if (!isFunction(eventOrCallback)) {
         space?.members.subscribe(eventOrCallback, listener);
       } else {
         space?.members.subscribe<any>(listener);
       }
 
       return () => {
-        if (isString(eventOrCallback)) {
+        if (!isFunction(eventOrCallback)) {
           space?.members.unsubscribe(eventOrCallback, listener);
         } else {
           space?.members.unsubscribe<any>(listener);


### PR DESCRIPTION
add `useCursors` variant without callback