### PR TITLE
[COL-577] Use ::$space as space channel suffix

### DIFF
--- a/docs/channel-usage.md
+++ b/docs/channel-usage.md
@@ -8,7 +8,7 @@ The below channels are used by the Spaces library internally.
 
 Each `Space` (as defined by the [`Space` class](https://sdk.ably.com/builds/ably/spaces/main/typedoc/classes/Space.html)) creates its own [Ably Channel](https://ably.com/docs/channels).
 
-The channel name is defined by the `name` of the Space and takes the form: `${name}-space`. The full name of a `channel` belonging to a `Space` called 'slides' would therefore be `slides-space`.
+The channel name is defined by the `name` of the Space and takes the form: `${name}::$space`. The full name of a `channel` belonging to a `Space` called 'slides' would therefore be `slides::$space`.
 
 ### Cursors
 

--- a/src/Space.test.ts
+++ b/src/Space.test.ts
@@ -48,7 +48,7 @@ describe('Space', () => {
 
       expect(channelSpy).toHaveBeenNthCalledWith(
         1,
-        'test-space',
+        'test::$space',
         expect.objectContaining({
           params: expect.objectContaining({
             agent: expect.stringContaining('spaces'),

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -15,8 +15,7 @@ import type { Subset, PresenceMember } from './utilities/types.js';
 
 import { VERSION } from './version.js';
 
-// Replace by ::$space when that channel tag will be available
-const SPACE_CHANNEL_TAG = '-space';
+const SPACE_CHANNEL_TAG = '::$space';
 
 const SPACE_OPTIONS_DEFAULTS = {
   offlineTimeout: 120_000,

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -29,7 +29,7 @@ describe('Spaces', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenNthCalledWith(
       1,
-      'test-space',
+      'test::$space',
       expect.objectContaining({
         params: expect.objectContaining({
           agent: expect.stringContaining('spaces'),


### PR DESCRIPTION
::$space is a channel tag and has special meaning within Ably, unlike the suffix `-space`.