### PR TITLE
[COL-526] Update and consolidate docstring comments

### DIFF
--- a/src/Locations.ts
+++ b/src/Locations.ts
@@ -12,6 +12,38 @@ import SpaceUpdate from './SpaceUpdate.js';
 export namespace LocationsEvents {
   /**
    * The data attached to an {@link LocationsEventMap.update | `update`} event.
+   *
+   * The following is an example payload of a location event:
+   *
+   * ```json
+   * {
+   *   "member": {
+   *     "clientId": "clemons#142",
+   *     "connectionId": "hd9743gjDc",
+   *     "isConnected": true,
+   *     "profileData": {
+   *       "username": "Claire Lemons",
+   *       "avatar": "https://slides-internal.com/users/clemons.png"
+   *     },
+   *     "location": {
+   *       "slide": "3",
+   *       "component": "slide-title"
+   *     },
+   *     "lastEvent": {
+   *       "name": "update",
+   *       "timestamp": 1972395669758
+   *     }
+   *   },
+   *   "previousLocation": {
+   *     "slide": "2",
+   *     "component": null
+   *   },
+   *   "currentLocation": {
+   *     "slide": "3",
+   *     "component": "slide-title"
+   *   }
+   * }
+   * ```
    */
   export interface UpdateEvent {
     /**
@@ -19,12 +51,10 @@ export namespace LocationsEvents {
      */
     member: SpaceMember;
     /**
-     * <!-- MOVED FROM Locations.subscribe -->
      * The new location of the member.
      */
     currentLocation: unknown;
     /**
-     * <!-- MOVED FROM Locations.subscribe -->
      * The previous location of the member.
      */
     previousLocation: unknown;
@@ -32,7 +62,7 @@ export namespace LocationsEvents {
 }
 
 /**
- * The property names of `LocationsEventMap` are the names of the events emitted by { @link Locations }.
+ * The property names of `LocationsEventMap` are the names of the events emitted by {@link Locations}.
  */
 export interface LocationsEventMap {
   /**
@@ -42,25 +72,10 @@ export interface LocationsEventMap {
 }
 
 /**
- * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locations.textile?plain=1#L9-L11) -->
- * The member location feature enables you to track where members are within a space, to see which part of your application they’re interacting with. A location could be the form field they have selected, the cell they’re currently editing in a spreadsheet, or the slide they’re viewing within a slide deck. Multiple members can be present in the same location.
+ * [Member locations](https://ably.com/docs/spaces/locations) enable you to track where members are within a {@link Space | space}, to see which part of your application they’re interacting with. A location could be the form field they have selected, the cell they’re currently editing in a spreadsheet, or the slide they’re viewing within a slide deck. Multiple members can be present in the same location.
  *
- * Member locations are used to visually display which component other members currently have selected, or are currently active on. Events are emitted whenever a member sets their location, such as when they click on a new cell, or slide. Events are received by members subscribed to location events and the UI component can be highlighted with the active member’s profile data to visually display their location.
+ * Location events are emitted whenever a member changes their location, such as by clicking on a new cell or slide. This enables UI components to be highlighted with the active member's profile data to visually display their location.
  *
- * <!-- END WEBSITE DOCUMENTATION -->
- *
- * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locations.textile?plain=1#L211-L215) -->
- * ## Member location foundations
- *
- * The Spaces SDK is built upon existing Ably functionality available in Ably’s Core SDKs. Understanding which core features are used to provide the abstractions in the Spaces SDK enables you to manage space state and build additional functionality into your application.
- *
- * Member locations build upon the functionality of the Pub/Sub Channels [presence](https://ably.com/docs/presence-occupancy/presence) feature. Members are entered into the presence set when they {@link Space.enter | enter the space}.
- *
- * <!-- END WEBSITE DOCUMENTATION -->
- *
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Handles the tracking of member locations within a space. Inherits from {@link EventEmitter}.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 export default class Locations extends EventEmitter<LocationsEventMap> {
   private lastLocationUpdate: Record<string, PresenceMember['data']['locationUpdate']['id']> = {};
@@ -103,26 +118,19 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locations.textile?plain=1#L15-L25) -->
-   * Use the `set()` method to emit a location event in realtime when a member changes their location. This will be received by all location subscribers to inform them of the location change. A `location` can be any JSON-serializable object, such as a slide number or element ID.
+   * Set the location of a member an emit an {@link LocationsEvents.UpdateEvent | `update`} event.
    *
-   * A member must have been { @link Space.enter | entered } into the space to set their location.
+   * A `location` can be any JSON-serializable object, such as a slide number or element ID.
    *
-   * The `set()` method is commonly combined with [`addEventListener()`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) or a React [synthetic event](https://react.dev/learn/responding-to-events#adding-event-handlers), such as `onClick` or `onHover`.
+   * A member must have been {@link Space.enter | entered} into the space to set their location.
    *
    * The following is an example of a member setting their location to a specific slide number, and element on that slide:
    *
    * ```javascript
    * await space.locations.set({ slide: '3', component: 'slide-title' });
    * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Set your current location. The `location` argument can be any JSON-serializable object. Emits a `locationUpdate` event to all connected clients in this space.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * <!-- Second sentence copied from above -->
-   * @param location The new location. Can be any JSON-serializable object, such as a slide number or element ID.
+   * @param location The member's new location. Can be any JSON-serializable object.
    */
   async set(location: unknown) {
     const self = await this.space.members.getSelf();
@@ -138,14 +146,13 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locations.textile?plain=1#L29-L91) -->
-   * Subscribe to location events by registering a listener. Location events are emitted whenever a member changes location by calling {@link set}.
+   * Subscribe to location events by registering a listener. Location events are emitted whenever a member {@link Locations.set | changes} their location.
    *
-   * All location changes are {@link LocationsEventMap.update | `update`} events. When a location update is received, clear the highlight from the UI component of the member’s {@link LocationsEvents.UpdateEvent.previousLocation | `previousLocation`} and add it to {@link LocationsEvents.UpdateEvent.currentLocation | `currentLocation`}.
+   * All location changes are `update` events. When a location update is received, clear the highlight from the UI component of the member’s {@link LocationsEvents.UpdateEvent.previousLocation | `previousLocation`} and add it to {@link LocationsEvents.UpdateEvent.currentLocation | `currentLocation`}.
    *
    * > **Note**
    * >
-   * > A location update is also emitted when a member {@link Space.leave | leaves} a space. The member’s {@link LocationsEvents.UpdateEvent.currentLocation | `currentLocation` } will be `null` for these events so that any UI component highlighting can be cleared.
+   * > A location update is also emitted when a member is {@link MembersEventMap.remove | removed} from a space. The member’s {@link LocationsEvents.UpdateEvent.currentLocation | `currentLocation` } will be `null` for these events so that any UI component highlighting can be cleared. Member location subscription listeners only trigger on events related to members’ locations. Each event only contains the payload of the member that triggered it. Alternatively, {@link Space.subscribe | space state } can be subscribed to which returns an array of all members with their latest state every time any event is triggered.
    *
    * The following is an example of subscribing to location events:
    *
@@ -154,65 +161,9 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
    *   console.log(locationUpdate);
    * });
    * ```
-   * The following is an example payload of a location event. Information about location is returned in {@link LocationsEvents.UpdateEvent.currentLocation | `currentLocation`} and {@link LocationsEvents.UpdateEvent.previousLocation | `previousLocation`}:
    *
-   * ```json
-   * {
-   *   "member": {
-   *     "clientId": "clemons#142",
-   *     "connectionId": "hd9743gjDc",
-   *     "isConnected": true,
-   *     "profileData": {
-   *       "username": "Claire Lemons",
-   *       "avatar": "https://slides-internal.com/users/clemons.png"
-   *     },
-   *     "location": {
-   *       "slide": "3",
-   *       "component": "slide-title"
-   *     },
-   *     "lastEvent": {
-   *       "name": "update",
-   *       "timestamp": 1972395669758
-   *     }
-   *   },
-   *   "previousLocation": {
-   *     "slide": "2",
-   *     "component": null
-   *   },
-   *   "currentLocation": {
-   *     "slide": "3",
-   *     "component": "slide-title"
-   *   }
-   * }
-   * ```
-   * The following are the properties of a location event payload:
-   *
-   * > **Moved documentation**
-   * >
-   * > This documentation has been moved to { @link LocationsEvents.UpdateEvent }.
-   *
-   * > **Further reading**
-   * >
-   * > Member location subscription listeners only trigger on events related to members’ locations. Each event only contains the payload of the member that triggered it. Alternatively, {@link Space.subscribe | space state } can be subscribed to which returns an array of all members with their latest state every time any event is triggered.
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Listen to events for locations. See {@link EventEmitter} for overloaded usage.
-   *
-   * Available events:
-   *
-   * - ##### **update**
-   *
-   *   Fires when a member updates their location. The argument supplied to the event listener is an UpdateEvent.
-   *
-   *   ```ts
-   *   space.locations.subscribe('update', (locationUpdate: LocationsEvents.UpdateEvent) => {});
-   *   ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to add.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link LocationsEventMap} type.
    */
@@ -221,9 +172,9 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
     listener?: EventListener<LocationsEventMap, K>,
   ): void;
   /**
-   * Behaves the same as { @link subscribe:WITH_EVENTS | the overload which accepts one or more event names }, but subscribes to _all_ events.
+   * Subscribe to location updates by registering a listener for all events.
    *
-   * @param listener The listener to add.
+   * @param listener An event listener.
    */
   subscribe(listener?: EventListener<LocationsEventMap, keyof LocationsEventMap>): void;
   subscribe<K extends keyof LocationsEventMap>(
@@ -246,7 +197,6 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locations.textile?plain=1#L95-L107) -->
    * Unsubscribe from location events to remove previously registered listeners.
    *
    * The following is an example of removing a listener for location update events:
@@ -254,23 +204,9 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
    * ```javascript
    * space.locations.unsubscribe('update', listener);
    * ```
-   * Or remove all listeners:
    *
-   * ```javascript
-   * space.locations.unsubscribe();
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Remove all event listeners, all event listeners for an event, or specific listeners. See {@link EventEmitter} for detailed usage.
-   *
-   * ```ts
-   * space.locations.unsubscribe('update');
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to remove.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link LocationsEventMap} type.
    */
@@ -279,9 +215,15 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
     listener?: EventListener<LocationsEventMap, K>,
   ): void;
   /**
-   * Behaves the same as { @link unsubscribe:WITH_EVENTS | the overload which accepts one or more event names }, but unsubscribes from _all_ events.
+   * Unsubscribe from all events to remove previously registered listeners.
    *
-   * @param listener The listener to remove.
+   * The following is an example of removing a listener for all events:
+   *
+   * ```javascript
+   * space.locations.unsubscribe(listener);
+   * ```
+   *
+   * @param listener An event listener.
    */
   unsubscribe(listener?: EventListener<LocationsEventMap, keyof LocationsEventMap>): void;
   unsubscribe<K extends keyof LocationsEventMap>(
@@ -302,18 +244,13 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
   }
 
   /**
-   * <!-- This is to avoid duplication of the website documentation. -->
-   * See the documentation for {@link getAll}.
+   * Retrieve the location of the current member in a one-off call.
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get location for self.
+   * The following is an example of retrieving a member's own location:
    *
-   * Example:
-   *
-   * ```ts
+   * ```javascript
    * const myLocation = await space.locations.getSelf();
    * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getSelf(): Promise<unknown> {
     const self = await this.space.members.getSelf();
@@ -321,18 +258,13 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
   }
 
   /**
-   * <!-- This is to avoid duplication of the website documentation. -->
-   * See the documentation for {@link getAll}.
+   * Retrieve the locations of all members other than the member themselves in a one-off call.
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get location for other members
+   * The following is an example of retrieving the locations of all members, except the member themselves:
    *
-   * Example:
-   *
-   * ```ts
+   * ```javascript
    * const otherLocations = await space.locations.getOthers()
    * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getOthers(): Promise<Record<string, unknown>> {
     const members = await this.space.members.getOthers();
@@ -344,75 +276,13 @@ export default class Locations extends EventEmitter<LocationsEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locations.textile?plain=1#L111-L172) -->
-   * Member locations can also be retrieved in one-off calls. These are local calls and retrieve the location of members retained in memory by the SDK.
+   * Retrieve the location of all members in a one-off call.
    *
-   * The following is an example of retrieving a member’s own location:
-   *
-   * ```javascript
-   * const myLocation = await space.locations.getSelf();
-   * ```
-   * The following is an example payload returned by `space.locations.getSelf()`. It will return the properties of the member’s `location`:
-   *
-   * ```json
-   * {
-   *   "slide": "3",
-   *   "component": "slide-title"
-   * }
-   * ```
-   * The following is an example of retrieving the location objects of all members other than the member themselves.
-   *
-   * ```javascript
-   * const othersLocations = await space.locations.getOthers();
-   * ```
-   * The following is an example payload returned by `space.locations.getOthers()`: It will return the properties of all member’s `location` by their `connectionId`:
-   *
-   * ```json
-   * {
-   *   "xG6H3lnrCn": {
-   *       "slide": "1",
-   *       "component": "textBox-1"
-   *   },
-   *   "el29SVLktW": {
-   *       "slide": "1",
-   *       "component": "image-2"
-   *   }
-   * }
-   * ```
-   * The following is an example of retrieving the location objects of all members, including the member themselves:
+   * The following is an example of retrieving the locations of all members:
    *
    * ```javascript
    * const allLocations = await space.locations.getAll();
    * ```
-   * The following is an example payload returned by `space.locations.getAll()`. It will return the properties of all member’s `location` by their `connectionId`:
-   *
-   * ```json
-   * {
-   *   "xG6H3lnrCn": {
-   *       "slide": "1",
-   *       "component": "textBox-1"
-   *   },
-   *   "el29SVLktW": {
-   *       "slide": "1",
-   *       "component": "image-2"
-   *   },
-   *   "dieF3291kT": {
-   *       "slide": "3",
-   *       "component": "slide-title"
-   *   }
-   * }
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get location for all members.
-   *
-   * Example:
-   *
-   * ```ts
-   * const allLocations = await space.locations.getAll();
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getAll(): Promise<Record<string, unknown>> {
     const members = await this.space.members.getAll();

--- a/src/Locks.ts
+++ b/src/Locks.ts
@@ -9,14 +9,12 @@ import EventEmitter, { InvalidArgumentError, inspect, type EventListener } from 
 import SpaceUpdate from './SpaceUpdate.js';
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
  * Additional attributes that can be set when acquiring a lock.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 export type LockAttributes = Record<string, unknown>;
 
 /**
- * Options for customizing the behaviour of {@link Locks.get | `Locks.get()`}.
+ * Options for customizing the behavior of {@link Locks.get | `Locks.get()`}.
  */
 export interface LockOptions {
   /**
@@ -26,7 +24,7 @@ export interface LockOptions {
 }
 
 /**
- * The property names of `LocksEventMap` are the names of the events emitted by { @link Locks }.
+ * The property names of `LocksEventMap` are the names of the events emitted by {@link Locks}.
  */
 export interface LocksEventMap {
   /**
@@ -36,26 +34,11 @@ export interface LocksEventMap {
 }
 
 /**
- * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L9-L37) -->
- * The component locking feature enables members to optimistically lock stateful UI components before editing them. This reduces the chances of conflicting changes being made to the same component by different members. A component could be a cell in a spreadsheet that a member is updating, or an input field on a form they’re filling in.
+ * [Component locking](https://ably.com/docs/spaces/locking) enables members to optimistically lock stateful UI components before editing them. This reduces the chances of conflicting changes being made to the same component by different members. A component could be a cell in a spreadsheet that a member is updating, or an input field on a form they’re filling in.
  *
  * Once a lock has been acquired by a member, the component that it relates to can be updated in the UI to visually indicate to other members that it is locked and and which member has the lock. The component can then be updated once the editing member has released the lock to indicate that it is now unlocked.
  *
- * Each lock is identified by a unique string ID, and only a single member may hold a lock with a given string at any one time. A lock will exist in one of three { @link LockStatus | states } and may only transition between states in specific circumstances.
- *
- * > **Important**
- * >
- * > Optimistic locking means that there is a chance that two members may begin editing the same UI component before it is confirmed which member holds the lock. On average, the time taken to reconcile which member holds a lock is in the hundreds of milliseconds. Your application needs to handle the member that successfully obtained the lock, as well as the member that had their request invalidated.
- *
- * ## Lock states
- *
- * Component locking is handled entirely client-side. Members may begin to optimistically edit a component as soon as they call {@link acquire | `acquire()` } on the lock identifier related to it. Alternatively, you could wait until they receive a `locked` event and display a spinning symbol in the UI until this is received. In either case a subsequent `unlocked` event may invalidate that member’s lock request if another member acquired it earlier. The time for confirmation of whether a lock request was successful or rejected is, on average, in the hundreds of milliseconds, however your code should handle all possible lock state transitions.
- *
- * A lock will be in one of the following states:
- *
- * > **Moved documentation**
- * >
- * > This documentation has been moved to { @link LockStatuses }.
+ * Each lock is identified by a unique string ID, and only a single member may hold a lock with a given string at any one time. A lock will exist in one of three {@link LockStatus | states} and may only transition between states in specific circumstances.
  *
  * The following lock state transitions may occur:
  *
@@ -65,13 +48,12 @@ export interface LocksEventMap {
  * - `locked` → `unlocked`: the lock was either explicitly {@link release | released} by the member, or their request was invalidated by a concurrent request which took precedence.
  * - `unlocked` → `locked`: the requesting member reacquired a lock they previously held.
  *
- * Only transitions that result in a `locked` or `unlocked` status will emit a lock event that members can {@link subscribe | `subscribe()` } to.
+ * Only lock transitions that result in a `locked` or `unlocked` status will emit a lock {@link LocksEventMap.update | update} event.
  *
- * <!-- END WEBSITE DOCUMENTATION -->
+ * > **Note**
+ * >
+ * > Optimistic locking means that there is a chance that two members may begin editing the same UI component before it is confirmed which member holds the lock. On average, the time taken to reconcile which member holds a lock is in the hundreds of milliseconds. Your application needs to handle the member that successfully obtained the lock, as well as the member that had their request invalidated.
  *
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Provides a mechanism to "lock" a component, reducing the chances of conflict in an application whilst being edited by multiple members. Inherits from {@link EventEmitter}.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 export default class Locks extends EventEmitter<LocksEventMap> {
   // locks tracks the local state of locks, which is used to determine whether
@@ -92,8 +74,7 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L171-L192) -->
-   * Use the `get()` method to query whether a lock is currently locked, and by which member if it is. The lock is identifiable by its unique string ID.
+   * Query whether a lock is currently locked, and if locked, return which member holds the lock. A lock is identifiable by its unique string ID.
    *
    * The following is an example of checking whether a lock identifier is currently locked:
    *
@@ -111,20 +92,8 @@ export default class Locks extends EventEmitter<LocksEventMap> {
    * const { request } = space.locks.get(id);
    * const viewLock = request.attributes.get(key);
    * ```
-   * If the lock is not currently held by a member, `get()` will return `undefined`. Otherwise it will return the most recent lock event for the lock.
    *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get a lock by its id.
-   *
-   * Example:
-   *
-   * ```ts
-   * const id = "/slide/1/element/3";
-   * const lock = space.locks.get(id);
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * If the lock is not currently held by a member, `get()` will return `undefined`.
    *
    * @param id A unique identifier which specifies the lock to query.
    */
@@ -142,69 +111,13 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   // This will be async in the future, when pending requests are no longer processed
   // in the library.
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L196-L247) -->
-   * Locks can also be retrieved in one-off calls. These are local calls and retrieve the locks retained in memory by the SDK.
+   * Retrieve all locks that are currently held in a one-off call. This is a local call that retrieves the latest locks retained in memory by the SDK.
    *
-   * The following is an example of retrieving an array of all currently held locks in a space:
+   * The following is an example of retrieving an array of all currently held locks:
    *
    * ```javascript
    * const allLocks = await space.locks.getAll();
    * ```
-   * The following is an example payload returned by `space.locks.getAll()`:
-   *
-   * ```json
-   * [
-   *   {
-   *     "id": "s1-c2",
-   *     "status": "locked",
-   *     "timestamp": 1247525627533,
-   *     "member": {
-   *       "clientId": "amint#5",
-   *       "connectionId": "hg35a4fgjAs",
-   *       "isConnected": true,
-   *         "lastEvent": {
-   *         "name": "update",
-   *       "timestamp": 173459567340
-   *       },
-   *       "location": null,
-   *       "profileData": {
-   *         "username": "Arit Mint",
-   *         "avatar": "https://slides-internal.com/users/amint.png"
-   *       }
-   *     }
-   *   },
-   *   {
-   *     "id": "s3-c4",
-   *     "status": "locked",
-   *     "timestamp": 1247115627423,
-   *     "member": {
-   *       "clientId": "torange#1",
-   *       "connectionId": "tt7233ghUa",
-   *       "isConnected": true,
-   *       "lastEvent": {
-   *         "name": "update",
-   *         "timestamp": 167759566354
-   *       },
-   *       "location": null,
-   *       "profileData": {
-   *         "username": "Tara Orange",
-   *         "avatar": "https://slides-internal.com/users/torange.png"
-   *       }
-   *     }
-   *   }
-   * ]
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get all locks that have the `locked` status.
-   *
-   * Example:
-   *
-   * ```ts
-   * const locks = await space.locks.getAll();
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getAll(): Promise<Lock[]> {
     const allLocks: Lock[] = [];
@@ -222,18 +135,13 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   }
 
   /**
-   * <!-- This is to avoid duplication of the website documentation. -->
-   * See the documentation for {@link getAll}.
+   * Retrieve all locks that are currently held by the current member in a one-off call. This is a local call that retrieves the latest locks retained in memory by the SDK.
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get all locks belonging to self that have the `locked` status.
+   * The following is an example of retrieving all locks held by the member:
    *
-   * Example:
-   *
-   * ```ts
+   * ```javascript
    * const locks = await space.locks.getSelf();
    * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getSelf(): Promise<Lock[]> {
     const self = await this.space.members.getSelf();
@@ -244,18 +152,13 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   }
 
   /**
-   * <!-- This is to avoid duplication of the website documentation. -->
-   * See the documentation for {@link getAll}.
+   * Retrieve all locks that are currently held by members except the member itself, in a one-off call. This is a local call that retrieves the latest locks retained in memory by the SDK.
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get all locks belonging to all members except self that have the `locked` status.
+   * The following is an example of retrieving all locks held by other members:
    *
-   * Example:
-   *
-   * ```ts
+   * ```javascript
    * const locks = await space.locks.getOthers();
    * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getOthers(): Promise<Lock[]> {
     const self = await this.space.members.getSelf();
@@ -267,8 +170,7 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L41-L72) -->
-   * Use the `acquire()` method to attempt to acquire a lock with a given unique ID. Additional `attributes` may be passed when trying to acquire a lock that can contain a set of arbitrary key-value pairs. An example of using `attributes` is to store the component ID the lock relates to so that it can be easily updated in the UI with a visual indication of its lock status.
+   * Attempt to acquire a lock with a given unique ID. Additional `attributes` may be passed when trying to acquire a lock that can contain a set of arbitrary key-value pairs. An example of using `attributes` is to store the component ID the lock relates to so that it can be easily updated in the UI with a visual indication of its lock status.
    *
    * A member must have been {@link Space.enter | entered } into the space to acquire a lock.
    *
@@ -277,41 +179,17 @@ export default class Locks extends EventEmitter<LocksEventMap> {
    * ```javascript
    * const acquireLock = await space.locks.acquire(id);
    * ```
+   *
    * The following is an example of passing a set of `attributes` when trying to acquire a lock:
    *
    * ```javascript
-   * const lockAttributes = new Map();
-   * lockAttributes.set('component', 'cell-d3');
+   * const lockAttributes = { 'component': 'cell-d3' };
    * const acquireLock = await space.locks.acquire(id, { lockAttributes });
    * ```
-   * The following is an example payload returned by `space.locks.acquire()`. The promise will resolve to a lock request with the `pending` status:
    *
-   * ```json
-   * {
-   *   "id": "s2-d14",
-   *   "status": "pending",
-   *   "timestamp": 1247525689781,
-   *   "attributes": {
-   *     "componentId": "cell-d14"
-   *   }
-   * }
-   * ```
-   * Once a member requests a lock by calling `acquire()`, the lock is temporarily in the {@link LockStatuses.Pending | pending state }. An event will be emitted based on whether the lock request was successful (a status of `locked`) or invalidated (a status of `unlocked`). This can be {@link subscribe | subscribed } to in order for the client to know whether their lock request was successful or not.
+   * Once a member requests a lock by calling `acquire()`, the lock is temporarily in the {@link LockStatuses.Pending | pending state }. An event will be emitted based on whether the lock request was successful (a status of {@link LockStatuses.Locked | `locked`}), or invalidated (a status of {@link LockStatuses.Unlocked | `unlocked`}).
    *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Send a request to acquire a lock. Returns a Promise which resolves once the request has been sent. A resolved Promise holds a `pending` {@link Lock}. An error will be thrown if a lock request with a status of `pending` or `locked` already exists, returning a rejected promise.
-   *
-   * When a lock acquisition by a member is confirmed with the `locked` status, an `update` event will be emitted. Hence to handle lock acquisition, `acquire()` needs to always be used together with `subscribe()`.
-   *
-   * Example:
-   *
-   * ```ts
-   * const id = "/slide/1/element/3";
-   * const lockRequest = await space.locks.acquire(id);
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * An error will be thrown if a lock request with a status of {@link LockStatuses.Pending | `pending`} or {@link LockStatuses.Locked | `locked`} already exists, returning a rejected promise.
    *
    * @param id A unique identifier which specifies the lock to acquire.
    * @param opts An object whose {@link LockOptions.attributes | `attributes`} property specifies additional metadata to associate with the lock.
@@ -350,32 +228,18 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L76-L88) -->
-   * Use the `release()` method to explicitly release a lock once a member has finished editing the related component. For example, the `release()` method can be called once a user clicks outside of the component, such as clicking on another cell within a spreadsheet. Any UI indications that the previous cell was locked can then be cleared.
+   * Release a lock once a member has finished editing the related component. For example, call `release()` once a user clicks outside of the component, such as clicking on another cell within a spreadsheet. Any UI indications that the previous cell was locked can then be cleared.
    *
    * The following is an example of releasing a lock:
    *
    * ```javascript
    * await space.locks.release(id);
    * ```
-   * Releasing a lock will emit a lock event with a {@link LockStatuses | lock status } of `unlocked`.
+   * Releasing a lock will emit a lock event with an {@link LockStatuses.Unlocked | `unlocked `} status.
    *
    * > **Note**
    * >
-   * > When a member {@link Space.leave | leaves } a space, their locks are automatically released.
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Releases a previously requested lock.
-   *
-   * Example:
-   *
-   * ```ts
-   * const id = "/slide/1/element/3";
-   * await space.locks.release(id);
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * > When a member is {@link MembersEventMap.remove | removed } from a space, their locks are automatically released.
    *
    * @param id A unique identifier which specifies the lock to release.
    */
@@ -398,8 +262,6 @@ export default class Locks extends EventEmitter<LocksEventMap> {
 
   /**
    * {@label WITH_EVENTS}
-   *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L92-L151) -->
    * Subscribe to lock events by registering a listener. Lock events are emitted whenever the {@link LockStatuses | lock state } transitions into `locked` or `unlocked`.
    *
    * All lock events are `update` events. When a lock event is received, UI components can be updated to add and remove visual indications of which member is locking them, as well as enabling and disabling the ability for other members to edit them.
@@ -411,73 +273,17 @@ export default class Locks extends EventEmitter<LocksEventMap> {
    *   console.log(lock);
    * });
    * ```
-   * The following is an example payload of a lock event:
    *
-   * ```json
-   * {
-   *   "id": "s2-d14",
-   *   "status": "unlocked",
-   *   "timestamp": 1247525689781,
-   *   "attributes": {
-   *     "componentId": "cell-d14"
-   *   },
-   *   "reason": {
-   *     "message": "lock is currently locked",
-   *     "code": 101003,
-   *     "statusCode": 400
-   *   },
-   *   "member": {
-   *     "clientId": "smango",
-   *     "connectionId": "hs343gjsdc",
-   *     "isConnected": true,
-   *     "profileData": {
-   *       "username": "Saiorse Mango"
-   *     },
-   *     "location": {
-   *       "slide": "sheet-2",
-   *       "component": "d-14"
-   *     },
-   *     "lastEvent": {
-   *       "name": "update",
-   *       "timestamp": 1247525689781
-   *     }
-   *   }
-   * }
-   * ```
-   * The following are the properties of a lock event payload:
-   *
-   * > **Moved documentation**
-   * >
-   * > This documentation has been moved to { @link Lock }.
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Listen to lock events. See {@link EventEmitter} for overloaded usage.
-   *
-   * Available events:
-   *
-   * - ##### **update**
-   *
-   *   Listen to changes to locks.
-   *
-   *   ```ts
-   *   space.locks.subscribe('update', (lock: Lock) => {})
-   *   ```
-   *
-   *   The argument supplied to the callback is a {@link Lock}, representing the lock request and it's status.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to add.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link LocksEventMap} type.
    */
   subscribe<K extends keyof LocksEventMap>(eventOrEvents: K | K[], listener?: EventListener<LocksEventMap, K>): void;
   /**
-   * Behaves the same as { @link subscribe:WITH_EVENTS | the overload which accepts one or more event names }, but subscribes to _all_ events.
+   *  Subscribe to lock updates by registering a listener for all events.
    *
-   * @param listener The listener to add.
+   * @param listener An event listener.
    */
   subscribe(listener?: EventListener<LocksEventMap, keyof LocksEventMap>): void;
   subscribe<K extends keyof LocksEventMap>(
@@ -500,7 +306,6 @@ export default class Locks extends EventEmitter<LocksEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/locking.textile?plain=1#L155-L166) -->
    * Unsubscribe from lock events to remove previously registered listeners.
    *
    * The following is an example of removing a listener for lock update events:
@@ -508,31 +313,23 @@ export default class Locks extends EventEmitter<LocksEventMap> {
    * ```javascript
    * space.locks.unsubscribe('update', listener);
    * ```
-   * Or remove all listeners:
    *
-   * ```javascript
-   * space.locks.unsubscribe();
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Remove all event listeners, all event listeners for an event, or specific listeners. See {@link EventEmitter} for detailed usage.
-   *
-   * ```ts
-   * space.locks.unsubscribe('update');
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to remove.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link LocksEventMap} type.
    */
   unsubscribe<K extends keyof LocksEventMap>(eventOrEvents: K | K[], listener?: EventListener<LocksEventMap, K>): void;
   /**
-   * Behaves the same as { @link unsubscribe:WITH_EVENTS | the overload which accepts one or more event names }, but unsubscribes from _all_ events.
+   * Unsubscribe from all events to remove previously registered listeners.
    *
-   * @param listener The listener to remove.
+   * The following is an example of removing a listener for all events:
+   *
+   * ```javascript
+   * space.locks.unsubscribe(listener);
+   * ```
+   *
+   * @param listener An event listener.
    */
   unsubscribe(listener?: EventListener<LocksEventMap, keyof LocksEventMap>): void;
   unsubscribe<K extends keyof LocksEventMap>(

--- a/src/Members.ts
+++ b/src/Members.ts
@@ -6,21 +6,18 @@ import type { PresenceMember } from './utilities/types.js';
 import type Space from './Space.js';
 
 /**
- * The property names of `MembersEventMap` are the names of the events emitted by { @link Members }.
+ * The property names of `MembersEventMap` are the names of the events emitted by {@link Members}.
  */
 export interface MembersEventMap {
   /**
-   * <!-- MOVED WITH EDITING FROM Members -->
-   * A member has left the space. The member has either left explicitly by calling { @link Space.leave | `space.leave()` }, or has abruptly disconnected and not re-established a connection within 15 seconds.
+   * A member has left the space. The member has either left explicitly by calling {@link Space.leave | `space.leave()`}, or has abruptly disconnected and not re-established a connection within 15 seconds.
    */
   leave: SpaceMember;
   /**
-   * <!-- MOVED WITH EDITING FROM Members -->
-   * A new member has entered the space. The member has either entered explicitly by calling {@link Space.enter | `space.enter()` }, or has attempted to update their profile data before entering a space, which will instead emit an `enter` event.
+   * A new member has entered the space. The member has either entered explicitly by calling {@link Space.enter | `space.enter()`}, or has attempted to update their profile data before entering a space, which will instead emit an `enter` event.
    */
   enter: SpaceMember;
   /**
-   * <!-- MOVED WITH EDITING FROM Members -->
    * This event is emitted whenever any one of the following events is emitted:
    *
    * - {@link enter}
@@ -30,49 +27,18 @@ export interface MembersEventMap {
    */
   update: SpaceMember;
   /**
-   * <!-- MOVED WITH EDITING FROM Members -->
-   * A member has updated their profile data by calling { @link Space.updateProfileData | `space.updateProfileData()` }.
+   * A member has updated their profile data by calling {@link Space.updateProfileData | `space.updateProfileData()`}.
    */
   updateProfile: SpaceMember;
   /**
-   * <!-- MOVED WITH EDITING FROM Members -->
-   * A member has been removed from the members list after the { @link SpaceOptions.offlineTimeout | `offlineTimeout` } period has elapsed. This enables members to appear greyed out in the avatar stack to indicate that they recently left for the period of time between their `leave` and `remove` events.
+   * A member has been removed from the members list after the {@link SpaceOptions.offlineTimeout | `offlineTimeout`} period has elapsed. This enables members to appear greyed out in the avatar stack to indicate that they recently left for the period of time between their `leave` and `remove` events.
    */
   remove: SpaceMember;
 }
 
 /**
- * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/avatar.textile?plain=1#L9-L25) -->
- * Avatar stacks are the most common way of showing the online status of members in an application by displaying an avatar for each member. Events are emitted whenever a member enters or leaves a space, or updates their profile data. Additional information can also be provided, such as a profile picture and email address.
+ * [Avatar stacks](https://ably.com/docs/spaces/avatar) are the most common way of showing the online status of members in an application by displaying an avatar for each member. {@link MembersEventMap | Events} are emitted whenever a member enters or leaves a space, or updates their profile data. Additional information can also be provided, such as a profile picture and email address.
  *
- * Subscribe to the space’s { @link Space.members | `members` } property in order to keep your avatar stack updated in realtime.
- *
- * ## Event types
- *
- * The following four event types are emitted by members:
- *
- * > **Moved documentation**
- * >
- * > This documentation has been moved to { @link MembersEventMap }.
- *
- * > **Note**
- * >
- * > Members {@link Space.enter | enter }, {@link Space.leave | leave }, and {@link Space.updateProfileData | update } a {@link Space | space } directly. The space’s { @link Space.members | `members` } property is used to subscribe to these updates.
- *
- * <!-- END WEBSITE DOCUMENTATION -->
- *
- * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/avatar.textile?plain=1#L297-L301) -->
- * ## Avatar stack foundations
- *
- * The Spaces SDK is built upon existing Ably functionality available in Ably’s Core SDKs. Understanding which core features are used to provide the abstractions in the Spaces SDK enables you to manage space state and build additional functionality into your application.
- *
- * Avatar stacks build upon the functionality of the Pub/Sub Channels [presence](https://ably.com/docs/presence-occupancy/presence) feature. Members are entered into the presence set when they { @link Space.enter | enter the space }.
- *
- * <!-- END WEBSITE DOCUMENTATION -->
- *
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Handles members within a space.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 class Members extends EventEmitter<MembersEventMap> {
   private lastMemberUpdate: Record<string, PresenceMember['data']['profileUpdate']['id']> = {};
@@ -113,153 +79,26 @@ class Members extends EventEmitter<MembersEventMap> {
   }
 
   /**
-   * <!-- This is to avoid duplication of the website documentation. -->
-   * See the documentation for {@link getAll}.
+   * Retrieve the current member's own member object in a one-off call.
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Returns a Promise which resolves to the {@link SpaceMember} object relating to the local connection. Will resolve to `null` if the client hasn't entered the space yet.
+   * The following is an example of retrieving a member's own member object:
    *
-   * Example:
-   *
-   * ```ts
-   * const myMember = await space.members.getSelf();
+   * ```javascript
+   * const myMemberInfo = await space.members.getSelf();
    * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getSelf(): Promise<SpaceMember | null> {
     return this.space.connectionId ? await this.getByConnectionId(this.space.connectionId) : null;
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/avatar.textile?plain=1#L129-L250) -->
-   * Space membership can be retrieved in one-off calls. These are local calls and retrieve the membership retained in memory by the SDK. One-off calls to retrieve membership can be used for operations such as displaying a member’s own profile data to them, or retrieving a list of all other members to use to {@link Space.updateProfileData | update their profile data }.
+   * Retrieve the member objects of all members within the space in a one-off call.
    *
-   * The following is an example of retrieving a member’s own member object:
-   *
-   * ```javascript
-   * const myMemberInfo = await space.members.getSelf();
-   * ```
-   * The following is an example payload returned by `space.members.getSelf()`:
-   *
-   * ```json
-   *   {
-   *     "clientId": "clemons#142",
-   *     "connectionId": "hd9743gjDc",
-   *     "isConnected": true,
-   *     "lastEvent": {
-   *       "name": "enter",
-   *       "timestamp": 1677595689759
-   *     },
-   *     "location": null,
-   *     "profileData": {
-   *       "username": "Claire Lemons",
-   *       "avatar": "https://slides-internal.com/users/clemons.png"
-   *     }
-   *   }
-   * ```
-   * The following is an example of retrieving an array of member objects for all members other than the member themselves. Ths includes members that have recently left the space, but have not yet been removed.
-   *
-   * ```javascript
-   * const othersMemberInfo = await space.members.getOthers();
-   * ```
-   * The following is an example payload returned by `space.members.getOthers()`:
-   *
-   * ```json
-   * [
-   *   {
-   *     "clientId": "torange#1",
-   *     "connectionId": "tt7233ghUa",
-   *     "isConnected": true,
-   *     "lastEvent": {
-   *       "name": "enter",
-   *       "timestamp": 167759566354
-   *     },
-   *     "location": null,
-   *     "profileData": {
-   *       "username": "Tara Orange",
-   *       "avatar": "https://slides-internal.com/users/torange.png"
-   *     }
-   *   },
-   *   {
-   *       "clientId": "amint#5",
-   *       "connectionId": "hg35a4fgjAs",
-   *       "isConnected": true,
-   *         "lastEvent": {
-   *         "name": "update",
-   *       "timestamp": 173459567340
-   *       },
-   *       "location": null,
-   *       "profileData": {
-   *         "username": "Arit Mint",
-   *         "avatar": "https://slides-internal.com/users/amint.png"
-   *       }
-   *   }
-   * ]
-   * ```
-   * The following is an example of retrieving an array of all member objects, including the member themselves. Ths includes members that have recently left the space, but have not yet been removed.
+   * The following is an example of retrieving all members:
    *
    * ```javascript
    * const allMembers = await space.members.getAll();
    * ```
-   * The following is an example payload returned by `space.members.getAll()`:
-   *
-   * ```json
-   * [
-   *   {
-   *     "clientId": "clemons#142",
-   *     "connectionId": "hd9743gjDc",
-   *     "isConnected": false,
-   *     "lastEvent": {
-   *       "name": "enter",
-   *       "timestamp": 1677595689759
-   *     },
-   *     "location": null,
-   *     "profileData": {
-   *       "username": "Claire Lemons",
-   *       "avatar": "https://slides-internal.com/users/clemons.png"
-   *     }
-   *   },
-   *   {
-   *       "clientId": "amint#5",
-   *       "connectionId": "hg35a4fgjAs",
-   *       "isConnected": true,
-   *         "lastEvent": {
-   *         "name": "update",
-   *       "timestamp": 173459567340
-   *       },
-   *       "location": null,
-   *       "profileData": {
-   *         "username": "Arit Mint",
-   *         "avatar": "https://slides-internal.com/users/amint.png"
-   *       }
-   *   },
-   *   {
-   *     "clientId": "torange#1",
-   *     "connectionId": "tt7233ghUa",
-   *     "isConnected": true,
-   *     "lastEvent": {
-   *       "name": "enter",
-   *       "timestamp": 167759566354
-   *     },
-   *     "location": null,
-   *     "profileData": {
-   *       "username": "Tara Orange",
-   *       "avatar": "https://slides-internal.com/users/torange.png"
-   *     }
-   *   }
-   * ]
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Returns a Promise which resolves to an array of all {@link SpaceMember} objects (members) currently in the space, including any who have left and not yet timed out. (_see: {@link SpaceOptions.offlineTimeout | offlineTimeout}_)
-   *
-   * Example:
-   *
-   * ```ts
-   * const allMembers = await space.members.getAll();
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getAll(): Promise<SpaceMember[]> {
     const presenceMembers = await this.space.channel.presence.get();
@@ -268,18 +107,13 @@ class Members extends EventEmitter<MembersEventMap> {
   }
 
   /**
-   * <!-- This is to avoid duplication of the website documentation. -->
-   * See the documentation for {@link getAll}.
+   * Retrieve the member objects of all members within the space other than the member themselves, in a one-off call.
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Returns a Promise which resolves to an array of all {@link SpaceMember} objects (members) currently in the space, excluding your own member object.
+   * The following is an example of retrieving all members other than the member themselves:
    *
-   * Example:
-   *
-   * ```ts
-   * const otherMembers = await space.members.getOthers();
+   * ```javascript
+   * const othersMemberInfo = await space.members.getOthers();
    * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   async getOthers(): Promise<SpaceMember[]> {
     const members = await this.getAll();
@@ -289,146 +123,34 @@ class Members extends EventEmitter<MembersEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/avatar.textile?plain=1#L29-L103) -->
-   * Subscribe to members’ online status and profile updates by registering a listener. Member events are emitted whenever a member {@link Space.enter | enters} or {@link Space.leave | leaves} the space, or updates their profile data. Use the `subscribe()` method on the `members` object of a space to receive updates.
+   * Subscribe to members’ online status and profile updates by registering a listener. Member events are emitted whenever a member {@link Space.enter | enters} or {@link Space.leave | leaves} the space, or {@link Space.updateProfileData | updates their profile data}.
    *
-   * The following is an example of subscribing to the different member event types:
+   * The following is an example of subscribing to enter events:
    *
    * ```javascript
-   * // Subscribe to member enters in a space
    * space.members.subscribe('enter', (memberUpdate) => {
    *   console.log(memberUpdate);
    * });
-   *
-   * // Subscribe to member profile data updates in a space
-   * space.members.subscribe('update', (memberUpdate) => {
-   *   console.log(memberUpdate);
-   * });
-   *
-   * // Subscribe to member leaves in a space
-   * space.members.subscribe('leave', (memberUpdate) => {
-   *   console.log(memberUpdate);
-   * });
-   *
-   * // Subscribe to member removals in a space
-   * space.members.subscribe('remove', (memberUpdate) => {
-   *   console.log(memberUpdate);
-   * });
    * ```
+   *
    * It’s also possible to subscribe to multiple event types with the same listener by using an array:
    *
    * ```javascript
-   * space.members.subscribe(['enter', 'update'], (memberUpdate) => {
+   * space.members.subscribe(['enter', 'leave'], (memberUpdate) => {
    *   console.log(memberUpdate);
    * });
    * ```
+   *
    * Or subscribe to all event types:
    *
    * ```javascript
-   * space.members.subscribe((memberUpdate) => {
+   * space.members.subscribe('update', (memberUpdate) => {
    *   console.log(memberUpdate);
    * });
    * ```
-   * The following is an example payload of a member event. The `lastEvent.name` describes which {@link SpaceEventMap | event type } a payload relates to.
    *
-   * ```json
-   *   {
-   *     "clientId": "clemons#142",
-   *     "connectionId": "hd9743gjDc",
-   *     "isConnected": true,
-   *     "lastEvent": {
-   *       "name": "enter",
-   *       "timestamp": 1677595689759
-   *     },
-   *     "location": null,
-   *     "profileData": {
-   *       "username": "Claire Lemons",
-   *       "avatar": "https://slides-internal.com/users/clemons.png"
-   *     }
-   *   }
-   * ```
-   * The following are the properties of a member event payload:
-   *
-   * | Property            | Description                                                                                                       | Type    |
-   * |---------------------|-------------------------------------------------------------------------------------------------------------------|---------|
-   * | clientId            | The [client identifier](https://ably.com/docs/auth/identified-clients) for the member.                                                 | String  |
-   * | connectionId        | The unique identifier of the member’s [connection](https://ably.com/docs/connect).                                                     | String  |
-   * | isConnected         | Whether the member is connected to Ably or not.                                                                   | Boolean |
-   * | profileData         | The optional {@link Space.updateProfileData | profile data } associated with the member.                                            | Object  |
-   * | location            | The current {@link Locations | location} of the member. Will be `null` for `enter`, `leave` and `remove` events. | Object  |
-   * | lastEvent.name      | This documentation has been moved to {@link SpaceMember}. | String  |
-   * | lastEvent.timestamp | This documentation has been moved to {@link SpaceMember}. | Number  |
-   *
-   * > **Further reading**
-   * >
-   * > Avatar stack subscription listeners only trigger on events related to members’ online status and profile updates. Each event only contains the payload of the member that triggered it. Alternatively, {@link Space.subscribe | space state } can be subscribed to which returns an array of all members with their latest state every time any event is triggered.
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Listen to member events for the space. See {@link EventEmitter} for overloaded usage.
-   *
-   * The argument supplied to the callback is the {@link SpaceMember} object representing the member that triggered the event.
-   *
-   * Example:
-   *
-   * ```ts
-   * space.members.subscribe((member: SpaceMember) => {});
-   * ```
-   *
-   * Available events:
-   *
-   * - ##### **enter**
-   *
-   *   Listen to enter events of members.
-   *
-   *   ```ts
-   *   space.members.subscribe('enter', (member: SpaceMember) => {})
-   *   ```
-   *   The argument supplied to the callback is a {@link SpaceMember} object representing the member entering the space.
-   *
-   * - ##### **leave**
-   *
-   *   Listen to leave events of members. The leave event will be issued when a member calls `space.leave()` or is disconnected.
-   *
-   *   ```ts
-   *   space.members.subscribe('leave', (member: SpaceMember) => {})
-   *   ```
-   *
-   *   The argument supplied to the callback is a {@link SpaceMember} object representing the member leaving the space.
-   *
-   * - ##### **remove**
-   *
-   *   Listen to remove events of members. The remove event will be triggered when the {@link SpaceOptions.offlineTimeout | offlineTimeout } has passed.
-   *
-   *   ```ts
-   *   space.members.subscribe('remove', (member: SpaceMember) => {})
-   *   ```
-   *
-   *   The argument supplied to the callback is a {@link SpaceMember} object representing the member removed from the space.
-   *
-   * - ##### **updateProfile**
-   *
-   *   Listen to profile update events of members.
-   *
-   *   ```ts
-   *   space.members.subscribe('updateProfile', (member: SpaceMember) => {})
-   *   ```
-   *   The argument supplied to the callback is a {@link SpaceMember} object representing the member entering the space.
-   *
-   * - ##### **update**
-   *
-   *   Listen to `enter`, `leave`, `updateProfile` and `remove` events.
-   *
-   *   ```ts
-   *   space.members.subscribe('update', (member: SpaceMember) => {})
-   *   ```
-   *
-   *   The argument supplied to the callback is a {@link SpaceMember} object representing the member affected by the change.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to add.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link MembersEventMap} type.
    */
@@ -437,9 +159,9 @@ class Members extends EventEmitter<MembersEventMap> {
     listener?: EventListener<MembersEventMap, K>,
   ): void;
   /**
-   * Behaves the same as { @link subscribe:WITH_EVENTS | the overload which accepts one or more event names }, but subscribes to _all_ events.
+   * Subscribe to members’ online status and profile updates by registering a listener for all event types.
    *
-   * @param listener The listener to add.
+   * @param listener An event listener.
    */
   subscribe(listener?: EventListener<MembersEventMap, keyof MembersEventMap>): void;
   subscribe<K extends keyof MembersEventMap>(
@@ -462,7 +184,6 @@ class Members extends EventEmitter<MembersEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/avatar.textile?plain=1#L107-L125) -->
    * Unsubscribe from member events to remove previously registered listeners.
    *
    * The following is an example of removing a listener for one member event type:
@@ -470,35 +191,15 @@ class Members extends EventEmitter<MembersEventMap> {
    * ```javascript
    * space.members.unsubscribe('enter', listener);
    * ```
+   *
    * It’s also possible to remove listeners for multiple member event types:
    *
    * ```javascript
    * space.members.unsubscribe(['enter', 'leave'], listener);
    * ```
-   * Or remove all listeners:
    *
-   * ```javascript
-   * space.members.unsubscribe();
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Remove all the event listeners or specific listeners. See {@link EventEmitter} for detailed usage.
-   *
-   * ```ts
-   * // Unsubscribe from all events
-   * space.members.unsubscribe();
-   *
-   * // Unsubscribe from enter events
-   * space.members.unsubscribe('enter');
-   *
-   * // Unsubscribe from leave events
-   * space.members.unsubscribe('leave');
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to remove.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link MembersEventMap} type.
    */
@@ -507,9 +208,9 @@ class Members extends EventEmitter<MembersEventMap> {
     listener?: EventListener<MembersEventMap, K>,
   ): void;
   /**
-   * Behaves the same as { @link unsubscribe:WITH_EVENTS | the overload which accepts one or more event names }, but unsubscribes from _all_ events.
+   * Unsubscribe from all events to remove previously registered listeners.
    *
-   * @param listener The listener to remove.
+   * @param listener An event listener.
    */
   unsubscribe(listener?: EventListener<MembersEventMap, keyof MembersEventMap>): void;
   unsubscribe<K extends keyof MembersEventMap>(

--- a/src/Space.ts
+++ b/src/Space.ts
@@ -41,7 +41,7 @@ export namespace SpaceEvents {
 }
 
 /**
- * The property names of `SpaceEventMap` are the names of the events emitted by { @link Space }.
+ * The property names of `SpaceEventMap` are the names of the events emitted by {@link Space}.
  */
 export interface SpaceEventMap {
   /**
@@ -69,8 +69,7 @@ export interface SpaceState {
 export type UpdateProfileDataFunction = (profileData: ProfileData) => ProfileData;
 
 /**
- * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L9-L22) -->
- * A space is a virtual area of your application in which realtime collaboration between users can take place. You can have any number of virtual spaces within an application, with a single space being anything from a web page, a sheet within a spreadsheet, an individual slide in a slideshow, or the entire slideshow itself.
+ * A [space](https://ably.com/docs/spaces/space) is a virtual area of your application in which realtime collaboration between users can take place. You can have any number of virtual spaces within an application, with a single space being anything from a web page, a sheet within a spreadsheet, an individual slide in a slideshow, or the entire slideshow itself.
  *
  * The following features can be implemented within a space:
  *
@@ -81,15 +80,6 @@ export type UpdateProfileDataFunction = (profileData: ProfileData) => ProfileDat
  *
  * A `Space` instance consists of a state object that represents the realtime status of all members in a given virtual space. This includes a list of which members are currently online or have recently left and each member’s location within the application. The position of members’ cursors are excluded from the space state due to their high frequency of updates. In the beta release, which UI components members have locked are also excluded from the space state.
  *
- * Space state can be {@link subscribe | subscribed} to by using a `Space` object. Alternatively, subscription listeners can be registered for individual features, such as avatar stack events and member location updates. These individual subscription listeners are intended to provide flexibility when implementing collaborative features. Individual listeners are client-side filtered events, so irrespective of whether you choose to subscribe to the space state or individual listeners, each event only counts as a single message.
- *
- * To subscribe to any events in a space, you first need to create or retrieve a space.
- *
- * <!-- END WEBSITE DOCUMENTATION -->
- *
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * An instance of a Space created using {@link default.get | spaces.get}. Inherits from {@link EventEmitter}.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 class Space extends EventEmitter<SpaceEventMap> {
   /**
@@ -102,33 +92,27 @@ class Space extends EventEmitter<SpaceEventMap> {
    */
   readonly connectionId: string | undefined;
   /**
-   * The options passed to {@link default.get | `Spaces.get()`}, with default values filled in.
+   * The options passed to {@link default.get | `Spaces.get()`}.
    */
   readonly options: SpaceOptions;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * An instance of {@link Locations}.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   readonly locations: Locations;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * An instance of {@link Cursors}.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   readonly cursors: Cursors;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * An instance of {@link Members}.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   readonly members: Members;
   /**
-   * The [ably-js](https://github.com/ably/ably-js) realtime channel instance that this `Cursors` instance uses for transmitting and receiving data.
+   * The [realtime channel instance](https://ably.com/docs/channels) that this `Space` instance uses for transmitting and receiving data.
    */
   readonly channel: Types.RealtimeChannelPromise;
   /**
-   * Provides access to the component locking feature for this space.
+   * An instance of {@link Locks}.
    */
   readonly locks: Locks;
   /**
@@ -200,30 +184,17 @@ class Space extends EventEmitter<SpaceEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L43-L55) -->
-   * Entering a space will register a client as a member and emit an {@link MembersEventMap.enter | `enter` } event to all subscribers. Use the `enter()` method to enter a space.
+   * Enter a space to register a client as a member and emit an {@link MembersEventMap.enter | `enter`} event to all subscribers.
+   *
+   * `profileData` can optionally be passed when entering a space. This data can be any arbitrary JSON-serializable object which will be attached to the {@link SpaceMember | member object}.
    *
    * Being entered into a space is required for members to:
    *
-   * - { @link updateProfileData | Update their profile data. }
-   * - { @link Locations.set | Set their location. }
-   * - { @link Cursors.set | Set their cursor position. }
+   * - {@link updateProfileData | Update their profile data.}
+   * - {@link Locations.set | Set their location.}
+   * - {@link Cursors.set | Set their cursor position.}
    *
-   * The following is an example of entering a space:
-   *
-   * ```javascript
-   * await space.enter();
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L71-L82) -->
-   * > **Moved documentation**
-   * >
-   * > This documentation has been moved to { @link ProfileData }.
-   *
-   * Profile data is returned in the payload of all space events.
-   *
-   * The following is an example of setting profile data when entering a space:
+   * The following is an example of entering a space and setting profile data:
    *
    * ```javascript
    * await space.enter({
@@ -231,13 +202,8 @@ class Space extends EventEmitter<SpaceEventMap> {
    *   avatar: 'https://slides-internal.com/users/coranges.png',
    * });
    * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
    *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Enter the space. Can optionally take `profileData`. This data can be an arbitrary JSON-serializable object which will be attached to the {@link SpaceMember | member object }. Returns all current space members.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param profileData Data to associate with the member who is entering the space.
+   * @param profileData The data to associate with a member, such as a preferred username or profile picture.
    */
   async enter(profileData: ProfileData = null): Promise<SpaceMember[]> {
     return new Promise((resolve) => {
@@ -273,47 +239,31 @@ class Space extends EventEmitter<SpaceEventMap> {
   /**
    * {@label MAIN_OVERLOAD}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L86-L103) -->
-   * Profile data can be updated at any point after entering a space by calling `updateProfileData()`. This will emit an `update` event. If a client hasn’t yet entered the space, `updateProfileData()` will instead {@link enter | enter the space }, with the profile data, and emit an { @link MembersEventMap.enter | `enter` } event.
+   * Update a member's profile data and emit an {@link MembersEventMap.updateProfile | `updateProfile`} event to all subscribers. This data can be any arbitrary JSON-serializable object which will be attached to the {@link SpaceMember | member object}.
    *
-   * The following is an example of updating profile data:
+   * If the client hasn't yet entered the space, `updateProfileData()` will instead enter them into the space, with the profile data, and emit an {@link MembersEventMap.enter | `enter`} event.
+   *
+   * The following is an example of a member updating their profile data:
    *
    * ```javascript
    * space.updateProfileData({
-   *   username: 'Claire Lemons',
-   *   avatar: 'https://slides-internal.com/users/clemons.png',
+   *   username: 'Claire Lime'
    * });
    * ```
-   * A function can be passed to `updateProfileData()` in order to update a field based on the existing profile data:
    *
-   * ```javascript
-   * space.updateProfileData(currentProfile => {
-   *   return { ...currentProfile, username: 'Clara Lemons' }
-   * });
-   * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Update `profileData`. This data can be an arbitrary JSON-serializable object which is attached to the {@link SpaceMember | member object }. If the connection
-   * has not entered the space, calling `updateProfileData` will call `enter` instead.
-   *
-   * A function can also be passed in. This function will receive the existing `profileData` and lets you update based on the existing value of `profileData`:
-   *
-   * ```ts
-   * await space.updateProfileData((oldProfileData) => {
-   *   const newProfileData = getNewProfileData();
-   *   return { ...oldProfileData, ...newProfileData };
-   * })
-   * ```
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param profileData The new profile data.
+   * @param profileData The updated profile data to associate with a member, such as a preferred username or profile picture.
    */
   async updateProfileData(profileData: ProfileData): Promise<void>;
   /**
-   * See the documentation for { @link updateProfileData:MAIN_OVERLOAD | the main overload }.
+   * Update a member's profile data by passing a function, for example to update a field based on the member's existing profile data:
    *
-   * @param updateFn A function which receives the existing profile data and returns the new profile data.
+   * ```javascript
+   * space.updateProfileData(currentProfile => {
+   *   return { ...currentProfile, username: 'Claire Lime' }
+   * });
+   * ```
+   *
+   * @param updateFn The function which receives the existing profile data and returns the new profile data.
    */
   async updateProfileData(updateFn: UpdateProfileDataFunction): Promise<void>;
   async updateProfileData(profileDataOrUpdateFn: ProfileData | UpdateProfileDataFunction): Promise<void> {
@@ -342,23 +292,13 @@ class Space extends EventEmitter<SpaceEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L59-L67) -->
-   * Leaving a space will emit a { @link MembersEventMap.leave | `leave` } event to all subscribers.
+   * Leave a space and emit a {@link MembersEventMap.leave | `leave`} event to all subscribers. `profileData` can optionally be updated when leaving the space.
    *
-   * The following is an example of explicitly leaving a space:
+   * The member may not immediately be removed from the space, depending on the {@link SpaceOptions.offlineTimeout | offlineTimeout} configured.
    *
-   * ```javascript
-   * await space.leave();
-   * ```
    * Members will implicitly leave a space after 15 seconds if they abruptly disconnect. If experiencing network disruption, and they reconnect within 15 seconds, then they will remain part of the space and no `leave` event will be emitted.
    *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Leave the space. Can optionally take `profileData`. This triggers the `leave` event, but does not immediately remove the member from the space. See {@link SpaceOptions.offlineTimeout | offlineTimeout }.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param profileData If specified, this updated profile data will accompany the { @link MembersEventMap.leave | `leave` } event.
+   * @param profileData The updated profile data to associate with a member.
    */
   async leave(profileData: ProfileData = null) {
     const self = await this.members.getSelf();
@@ -381,15 +321,13 @@ class Space extends EventEmitter<SpaceEventMap> {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L191-L197) -->
-   * The current state of the space can be retrieved in a one-off call. This will return an array of all `member` objects currently in the space. This is a local call and retrieves the membership of the space retained in memory by the SDK.
+   * Retrieve the current state of a space in a one-off call. Returns an array of all `member` objects currently in the space. This is a local call and retrieves the membership of the space retained in memory by the SDK.
    *
-   * The following is an example of retrieving the current space state. Ths includes members that have recently left the space, but have not yet been removed:
+   * The following is an example of retrieving space state:
    *
    * ```javascript
    * const spaceState = await space.getState();
    * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
    */
   async getState(): Promise<SpaceState> {
     const members = await this.members.getAll();
@@ -399,14 +337,13 @@ class Space extends EventEmitter<SpaceEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L107-L177) -->
-   * Subscribe to space state updates by registering a listener. Use the `subscribe()` method on the `space` object to receive updates.
+   * Subscribe to space state updates by registering a listener for an event name, or an array of event names.
    *
    * The following events will trigger a space event:
    *
    * - A member enters the space
    * - A member leaves the space
-   * - A member is removed from the space state { @link SpaceOptions.offlineTimeout | after the offlineTimeout period } has elapsed
+   * - A member is removed from the space state after the {@link SpaceOptions.offlineTimeout | offlineTimeout} period has elapsed
    * - A member updates their profile data
    * - A member sets a new location
    *
@@ -414,7 +351,7 @@ class Space extends EventEmitter<SpaceEventMap> {
    *
    * > **Note**
    * >
-   * > Avatar stacks and member location events can be subscribed to using the space’s {@link members | `members` } and {@link locations | `locations` } properties.0These events are filtered versions of space state events. Only a single [message](https://ably.com/docs/channels/messages) is published per event by Ably, irrespective of whether you register listeners for space state or individual namespaces. If you register listeners for both, it is still only a single message.
+   * > Avatar stacks and member location events can be subscribed to using the space’s {@link members | `members`} and {@link locations | `locations`} properties. These events are filtered versions of space state events. Only a single [message](https://ably.com/docs/channels/messages) is published per event by Ably, irrespective of whether you register listeners for space state or individual namespaces. If you register listeners for both, it is still only a single message.
    * >
    * > The key difference between the subscribing to space state or to individual feature events, is that space state events return the current state of the space as an array of all members in each event payload. Individual member and location event payloads only include the relevant data for the member that triggered the event.
    *
@@ -425,64 +362,17 @@ class Space extends EventEmitter<SpaceEventMap> {
    *   console.log(spaceState.members);
    * });
    * ```
-   * The following is an example payload of a space event.
    *
-   * ```json
-   * [
-   *     {
-   *         "clientId": "clemons#142",
-   *         "connectionId": "hd9743gjDc",
-   *         "isConnected": false,
-   *         "lastEvent": {
-   *           "name": "leave",
-   *           "timestamp": 1677595689759
-   *         },
-   *         "location": null,
-   *         "profileData": {
-   *           "username": "Claire Lemons",
-   *           "avatar": "https://slides-internal.com/users/clemons.png"
-   *         }
-   *     },
-   *     {
-   *         "clientId": "amint#5",
-   *         "connectionId": "hg35a4fgjAs",
-   *         "isConnected": true,
-   *           "lastEvent": {
-   *           "name": "enter",
-   *         "timestamp": 173459567340
-   *         },
-   *         "location": null,
-   *         "profileData": {
-   *           "username": "Arit Mint",
-   *           "avatar": "https://slides-internal.com/users/amint.png"
-   *         }
-   *     },
-   *     ...
-   * ]
-   * ```
-   * The following are the properties of an individual `member` within a space event payload:
-   *
-   * | Property            | Description                                                            | Type    |
-   * |---------------------|------------------------------------------------------------------------|---------|
-   * | clientId            | The [client identifier](https://ably.com/docs/auth/identified-clients) for the member.      | String  |
-   * | connectionId        | The unique identifier of the member’s [connection](https://ably.com/docs/connect).          | String  |
-   * | isConnected         | Whether the member is connected to Ably or not.                        | Boolean |
-   * | profileData         | The optional {@link updateProfileData | profile data } associated with the member. | Object  |
-   * | location            | The current { @link Locations | location } of the member.               | Object  |
-   * | lastEvent.name      | The most recent event emitted by the member.                           | String  |
-   * | lastEvent.timestamp | The timestamp of the most recently emitted event.                      | Number  |
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * @param eventOrEvents The event name or an array of event names.  * @param listener The listener to add.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link SpaceEventMap} type.
    */
   subscribe<K extends keyof SpaceEventMap>(eventOrEvents: K | K[], listener?: EventListener<SpaceEventMap, K>): void;
   /**
-   * Behaves the same as { @link subscribe:WITH_EVENTS | the overload which accepts one or more event names }, but subscribes to _all_ events.
+   * Subscribe to space state updates by registering a listener for all event types.
    *
-   * @param listener The listener to add.
+   * @param listener An event listener.
    */
   subscribe(listener?: EventListener<SpaceEventMap, keyof SpaceEventMap>): void;
   subscribe<K extends keyof SpaceEventMap>(
@@ -505,26 +395,30 @@ class Space extends EventEmitter<SpaceEventMap> {
   /**
    * {@label WITH_EVENTS}
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L181-L187) -->
-   * Unsubscribe from space events to remove previously registered listeners.
+   * Unsubscribe from specific events, or an array of event names, to remove previously registered listeners.
    *
    * The following is an example of removing a listener:
    *
    * ```javascript
    * space.unsubscribe('update', listener);
    * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
    *
-   * @param eventOrEvents The event name or an array of event names.
-   * @param listener The listener to remove.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of the {@link SpaceEventMap} type.
    */
   unsubscribe<K extends keyof SpaceEventMap>(eventOrEvents: K | K[], listener?: EventListener<SpaceEventMap, K>): void;
   /**
-   * Behaves the same as { @link unsubscribe:WITH_EVENTS | the overload which accepts one or more event names }, but unsubscribes from _all_ events.
+   * Unsubscribe from all events to remove previously registered listeners.
    *
-   * @param listener The listener to remove.
+   * The following is an example of removing a listener for all events:
+   *
+   * ```javascript
+   * space.unsubscribe(listener);
+   * ```
+   *
+   * @param listener An event listener.
    */
   unsubscribe(listener?: EventListener<SpaceEventMap, keyof SpaceEventMap>): void;
   unsubscribe<K extends keyof SpaceEventMap>(

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -17,42 +17,30 @@ export interface ClientWithOptions extends Types.RealtimePromise {
 /**
  * The `Spaces` class is the entry point to the Spaces SDK. Use its {@link get | `get()`} method to access an individual {@link Space | `Space`}.
  *
- * To create an instance of `Spaces`, you first need to create an instance of the [ably-js](https://github.com/ably/ably-js) Realtime client.  You then pass this instance to the {@link constructor | `Spaces()` constructor}.
+ * To create an instance of `Spaces`, you first need to create an instance of an [Ably realtime client](https://ably.com/docs/getting-started/setup). You then pass this instance to the {@link constructor | Spaces constructor}.
  */
 class Spaces {
   private spaces: Record<string, Space> = {};
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Instance of the [ably-js](https://github.com/ably/ably-js) client that was passed to the {@link constructor}.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * Instance of the [Ably realtime client](https://ably.com/docs/getting-started/setup) client that was passed to the {@link constructor}.
    */
   client: Types.RealtimePromise;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Instance of the [ably-js](https://github.com/ably/ably-js) connection, belonging to the client that was passed to the {@link constructor}.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * Instance of the [Ably realtime client](https://ably.com/docs/getting-started/setup) connection, belonging to the client that was passed to the {@link constructor}.
    */
   connection: Types.ConnectionPromise;
 
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * Version of the Spaces library.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   readonly version = VERSION;
 
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Create a new instance of the Space SDK by passing an instance of the realtime, promise-based [Ably client](https://github.com/ably/ably-js):
+   * Create a new instance of the Spaces SDK by passing an instance of the [Ably promise-based realtime client](https://ably.com/docs/getting-started/setup). A [`clientId`](https://ably.com/docs/auth/identified-clients) is required.
    *
-   * Please note that a [clientId](https://ably.com/docs/auth/identified-clients?lang=javascript) is required.
+   * An Ably API key is needed to authenticate. [Basic authentication](https://ably.com/docs/auth/basic) may be used for convenience, however Ably strongly recommends you use [token authentication](https://ably.com/docs/auth/token) in a production environment.
    *
-   * An API key will required for [basic authentication](https://ably.com/docs/auth/basic?lang=javascript). We strongly recommended that you use [token authentication](https://ably.com/docs/realtime/authentication#token-authentication) in any production environments.
-   *
-   * Refer to the [Ably docs for the JS SDK](https://ably.com/docs/getting-started/setup?lang=javascript) for information on setting up a realtime promise client.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
-   *
-   * @param client An instance of the realtime, promise-based Ably client from [ably-js](https://github.com/ably/ably-js).
+   * @param client An instance of the Ably prmise-based realtime client.
    */
   constructor(client: Types.RealtimePromise) {
     this.client = client;
@@ -67,42 +55,18 @@ class Spaces {
   }
 
   /**
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L26-L39) -->
-   * A `space` object is a reference to a single space and is uniquely identified by its unicode string name. A space is created, or an existing space is retrieved from the `spaces` collection using the {@link get | `get()`} method.
    *
-   * The following restrictions apply to space names:
-   *
-   * - Avoid starting names with `[` or `:`
-   * - Ensure names aren’t empty
-   * - Exclude whitespace and wildcards, such as `*`
-   * - Use the correct case, whether it be uppercase or lowercase
+   * Create or retrieve an existing [space](https://ably.com/docs/spaces/space) from the `Spaces` collection. A space is uniquely identified by its unicode string name.
    *
    * The following is an example of creating a space:
    *
    * ```javascript
    * const space = await spaces.get('board-presentation');
    * ```
-   * <!-- END WEBSITE DOCUMENTATION -->
    *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/space.textile?plain=1#L199-L242) -->
-   * ## Advanced properties
+   * A set of {@link SpaceOptions | options} may be passed when creating a space to customize a space.
    *
-   * The following sections are only relevant if you want to further customize a space, or understand more about the Spaces SDK. They aren’t required to get up and running with the basics.
-   *
-   * ### Space options
-   *
-   * An additional set of optional properties may be passed when {@link get | creating or retrieving } a space to customize the behavior of different features.
-   *
-   * The following properties can be customized:
-   *
-   * | Property                      | Description                                                                                                                                                                       | Type   |
-   * |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|
-   * | offlineTimeout                | Number of milliseconds after a member loses connection or closes their browser window to wait before they are removed from the member list. The default is 120,000ms (2 minutes). | Number |
-   * | cursors                       | A {@link CursorsOptions | cursor options} object for customizing live cursor behavior.                                                                                          | Object |
-   * | cursors.outboundBatchInterval | The interval, in milliseconds, at which a batch of cursor positions are published. This is multiplied by the number of members in a space, minus 1. The default value is 100ms.   | Number |
-   * | cursors.paginationLimit       | The number of pages searched from history for the last published cursor position. The default is 5.                                                                               | Number |
-   *
-   * The following is an example of customizing the space options when calling `spaces.get()`:
+   * The following is an example of setting custom `SpaceOptions`:
    *
    * ```javascript
    * const space = await spaces.get('board-presentation', {
@@ -110,53 +74,9 @@ class Spaces {
    * 	cursors: { paginationLimit: 10 }
    * });
    * ```
-   * ### Space foundations
-   *
-   * The Spaces SDK is built upon existing Ably functionality available in Ably’s Core SDKs. Understanding which core features are used to provide the abstractions in the Spaces SDK enables you to manage space state and build additional functionality into your application.
-   *
-   * A space is created as an Ably [channel](/channels). Members [attach](https://ably.com/docs/channels#attach) to the channel and join its [presence set](https://ably.com/docs/presence-occupancy/presence) when they { @link Space.enter | enter } the space. Avatar stacks, member locations and component locking are all handled on this channel.
-   *
-   * To manage the state of the space, you can monitor the [state of the underlying channel](https://ably.com/docs/channels#states). The channel object can be accessed through {@link Space.channel | `space.channel`}.
-   *
-   * The following is an example of registering a listener to wait for a channel to become attached:
-   *
-   * ```javascript
-   * space.channel.on('attached', (stateChange) => {
-   *   console.log(stateChange)
-   * });
-   * ```
-   *
-   * > **Note**
-   * >
-   * > Due to the high frequency at which updates are streamed for cursor movements, live cursors utilizes its own [channel](https://ably.com/docs/channels).
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN WEBSITE DOCUMENTATION (https://github.com/ably/docs/blob/cb5de6a6a40abdcb0d9d5af825928dd62dc1ca64/content/spaces/cursors.textile?plain=1#L108-L122) -->
-   * ## Cursor options
-   *
-   * Cursor options are set when creating or retrieving a {@link Space | `Space` } instance. They are used to control the behavior of live cursors.
-   *
-   * The following cursor options can be set:
-   *
-   * ### outboundBatchInterval
-   *
-   * The `outboundBatchInterval` is the interval at which a batch of cursor positions are published, in milliseconds, for each client. This is multiplied by the number of members in a space.
-   *
-   * The default value is 25ms which is optimal for the majority of use cases. If you wish to optimize the interval further, then decreasing the value will improve performance by further ‘smoothing’ the movement of cursors at the cost of increasing the number of events sent. Be aware that at a certain point the rate at which a browser is able to render the changes will impact optimizations.
-   *
-   * ### paginationLimit
-   *
-   * The volume of messages sent can be high when using live cursors. Because of this, the last known position of every members’ cursor is obtained from [history](https://ably.com/docs/storage-history/history). The `paginationLimit` is the number of pages that should be searched to find the last position of each cursor. The default is 5.
-   *
-   * <!-- END WEBSITE DOCUMENTATION -->
-   *
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Get or create a Space instance. Returns a {@link Space} instance. Configure the space by passing {@link SpaceOptions} as the second argument.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    *
    * @param name The name of the space to create or retrieve.
-   * @param options Additional options to customize the behaviour of the space.
+   * @param options Additional options to customize the behavior of the space.
    */
   async get(name: string, options?: Subset<SpaceOptions>): Promise<Space> {
     if (typeof name !== 'string' || name.length === 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,151 +2,149 @@ import { Types } from 'ably';
 import type { LockAttributes } from './Locks.js';
 
 /**
- * Options to configure the behaviour of a {@link Cursors | `Cursors`} instance.
+ * Options to configure the behavior of a {@link Cursors | `Cursors`} instance.
  */
 export interface CursorsOptions {
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * The interval in milliseconds at which a batch of cursor positions are published. This is multiplied by the number of members in the space minus 1. The default value is 25ms.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * The interval, in milliseconds, at which a batch of cursor positions are published. This is multiplied by the number of members in a space, minus 1. The default value is 25ms. Decreasing the value will improve performance by further ‘smoothing’ the movement of cursors at the cost of increasing the number of events sent.
    */
   outboundBatchInterval: number;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * The number of pages searched from [history](https://ably.com/docs/storage-history/history) for the last published cursor position. The default is 5.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   paginationLimit: number;
 }
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
  * Represents a cursors position.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 export interface CursorPosition {
   /**
-   * <!-- MOVED FROM Cursors.set -->
    * The position of the member’s cursor on the X-axis.
    */
   x: number;
   /**
-   * <!-- MOVED FROM Cursors.set -->
    * The position of the member’s cursor on the Y-axis.
    */
   y: number;
 }
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Represent data that can be associated with a cursor update.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+ * Represents data that can be associated with a cursor update. A JSON-serializable object containing additional information about the cursor, such as a color or the ID of an element the cursor is dragging.
  */
 export type CursorData = Record<string, unknown>;
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Represents an update to a cursor.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+ * Represents a cursor update event.
+ *
+ * The following is an example payload of a cursor event. Cursor events are uniquely identifiable by the {@link CursorUpdate.connectionId | `connectionId`} of a cursor.
+ *
+ * ```json
+ * {
+ *   "hd9743gjDc": {
+ *     "connectionId": "hd9743gjDc",
+ *     "clientId": "clemons#142",
+ *     "position": {
+ *       "x": 864,
+ *       "y": 32
+ *     },
+ *     "data": {
+ *       "color": "red"
+ *     }
+ *   }
+ * }
+ * ```
  */
 export interface CursorUpdate {
   /**
-   * <!-- MOVED FROM Cursors.set -->
    * The [client identifier](https://ably.com/docs/auth/identified-clients) for the member.
    */
   clientId: string;
   /**
-   * <!-- MOVED FROM Cursors.set -->
    * The unique identifier of the member’s [connection](https://ably.com/docs/connect).
    */
   connectionId: string;
   /**
-   * <!-- MOVED FROM Cursors.set -->
    * An object containing the position of a member’s cursor.
    */
   position: CursorPosition;
   /**
-   * <!-- MOVED FROM Cursors.set -->
    * An optional arbitrary JSON-serializable object containing additional information about the cursor.
    */
   data?: CursorData;
 }
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Used to configure a Space instance on creation.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+ * Options to configure a {@link Space | Space} instance on its creation.
  */
 export interface SpaceOptions {
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * Number of milliseconds after a user loses connection or closes their browser window to wait before their {@link SpaceMember} object is removed from the members list. The default is 120000ms (2 minutes).
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   offlineTimeout: number;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Options relating to configuring the cursors API (see below).
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * Options to configure live cursors behavior.
    */
   cursors: CursorsOptions;
 }
 
 /**
- * <!-- MOVED WITH EDITING FROM Space.enter -->
- * Profile data can be set when {@link Space.enter | entering } a space. It is optional data that can be used to associate information with a member, such as a preferred username, or profile picture that can be subsequently displayed in their avatar. Profile data can be any arbitrary JSON-serializable object.
+ * Optional data that is associated with a member. Examples include a preferred username, or a profile picture that can be subsequently displayed in their avatar. Can be any arbitrary JSON-serializable object.
  */
 export type ProfileData = Record<string, unknown> | null;
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * A SpaceMember represents a member within a Space instance. Each new connection that enters will create a new member, even if they have the same [`clientId`](https://ably.com/docs/auth/identified-clients?lang=javascript).
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+ * Represents a member within a Space instance. Each new connection that enters will create a new member, even if they have the same [`clientId`](https://ably.com/docs/auth/identified-clients).
+ *
+ * The following is an example payload of a `SpaceMember`:
+ *
+ * ```json
+ * {
+ *  "clientId": "clemons#142",
+ *  "connectionId": "hd9743gjDc",
+ *  "isConnected": false,
+ *  "lastEvent": {
+ *    "name": "leave",
+ *    "timestamp": 1677595689759
+ *  },
+ *  "location": null,
+ *  "profileData": {
+ *    "username": "Claire Lemons",
+ *    "avatar": "https://slides-internal.com/users/clemons.png"
+ *    }
+ * }
+ * ```
  */
 export interface SpaceMember {
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * The client identifier for the user, provided to the ably client instance.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * The [client identifier](https://ably.com/docs/auth/identified-clients) for the member.
    */
   clientId: string;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Identifier for the connection used by the user. This is a unique identifier.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * The unique identifier of the member’s [connection](https://ably.com/docs/connect).
    */
   connectionId: string;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Whether the user is connected to Ably.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * Whether the user is connected to Ably or not.
    */
   isConnected: boolean;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * Optional user data that can be attached to a user, such as a username or image to display in an avatar stack.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * Optional data that is associated with a member, such as a preferred username or profile picture to display in an avatar stack.
    */
   profileData: ProfileData;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
    * The current location of the user within the space.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
    */
   location: unknown;
   /**
-   * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
-   * The most recent event emitted by [presence](https://ably.com/docs/presence-occupancy/presence?lang=javascript) and its timestamp. Events will be either `enter`, `leave`, `update` or `present`.
-   * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+   * The most recent event emitted by [presence](https://ably.com/docs/presence-occupancy/presence) and its timestamp. Events will be either `enter`, `leave`, `update` or `present`.
    */
   lastEvent: {
     /**
-     * <!-- MOVED FROM Locations.subscribe -->
      * The most recent event emitted by the member.
      */
     name: Types.PresenceAction;
     /**
-     * <!-- MOVED FROM Locations.subscribe -->
      * The timestamp of the most recently emitted event.
      */
     timestamp: number;
@@ -154,66 +152,54 @@ export interface SpaceMember {
 }
 
 /**
- * The `LockStatuses` namespace describes the possible values of the {@link LockStatus} type.
+ * Describes the possible values of the {@link LockStatus} type.
  */
 export namespace LockStatuses {
   /**
-   * <!-- MOVED WITH EDITING FROM Locks -->
-   * A member has requested a lock by calling { @link Locks.acquire | `acquire()` }.
+   * A member has requested a lock by calling {@link Locks.acquire | `acquire()`}.
    */
   export type Pending = 'pending';
   /**
-   * <!-- MOVED FROM Locks -->
-   * The lock is confirmed to be held by the requesting member.
+   * A lock is confirmed to be held by the requesting member.
    */
   export type Locked = 'locked';
   /**
-   * <!-- MOVED WITH EDITING FROM Locks -->
-   * The lock is confirmed to not be locked by the requesting member, or has been { @link Locks.release | released } by a member previously holding the lock.
+   * A lock is confirmed to not be locked by the requesting member, or has been {@link Locks.release | released} by a member previously holding the lock.
    */
   export type Unlocked = 'unlocked';
 }
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
- * Represents a status of a lock.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
+ * Represents the status of a lock.
  */
 export type LockStatus = LockStatuses.Pending | LockStatuses.Locked | LockStatuses.Unlocked;
 
 /**
- * <!-- BEGIN CLASS-DEFINITIONS DOCUMENTATION -->
  * Represents a Lock.
- * <!-- END CLASS-DEFINITIONS DOCUMENTATION -->
  */
 export type Lock = {
   /**
-   * <!-- MOVED FROM Locks.subscribe -->
    * The unique ID of the lock request.
    */
   id: string;
   /**
-   * <!-- MOVED WITH EDITING FROM Locks.subscribe -->
-   * The lock status of the event.
+   * The status of the lock event.
    */
   status: LockStatus;
   /**
-   * Information about the space member who requested the lock.
+   * Information about the member who requested the lock.
    */
   member: SpaceMember;
   /**
-   * <!-- MOVED FROM Locks.subscribe -->
    * The timestamp of the lock event.
    */
   timestamp: number;
   /**
-   * <!-- MOVED FROM Locks.subscribe -->
    * The optional attributes of the lock, such as the ID of the component it relates to.
    */
   attributes?: LockAttributes;
   /**
-   * <!-- MOVED FROM Locks.subscribe -->
-   * The reason why the `request.status` is `unlocked`.
+   * The reason why the lock status is {@link LockStatuses.Unlocked | `unlocked`}.
    */
   reason?: Types.ErrorInfo;
 };

--- a/src/utilities/EventEmitter.ts
+++ b/src/utilities/EventEmitter.ts
@@ -115,16 +115,16 @@ export default class EventEmitter<T> {
 
   /**
    * {@label WITH_EVENTS}
-   * Add an event listener
-   * @param eventOrEvents the name of the event to listen to or the listener to be called.
-   * @param listener (optional) the listener to be called.
+   * Add an event listener.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows one or more names of the properties of {@link T}.
    */
   on<K extends keyof T>(eventOrEvents?: K | K[], listener?: EventListener<T, K>): void;
   /**
-   * Behaves the same as { @link on:WITH_EVENTS | the overload which accepts one or more event names }, but listens to _all_ events.
-   * @param listener (optional) the listener to be called.
+   * Add an event listener for all event types.
+   * @param listener An event listener.
    */
   on(listener?: EventListener<T, keyof T>): void;
   /**
@@ -159,16 +159,16 @@ export default class EventEmitter<T> {
 
   /**
    * {@label WITH_EVENTS}
-   * Remove one or more event listeners
-   * @param eventOrEvents the name of the event whose listener is to be removed.
-   * @param listener (optional) the listener to remove. If not supplied, all listeners are removed.
+   * Remove one or more event listeners.
+   * @param eventOrEvents An event name, or an array of event names.
+   * @param listener An event listener. If not supplied, all listeners are removed.
    *
    * @typeParam K A type which allows one or more names of the properties of {@link T}. TypeScript will infer this type based on the {@link eventOrEvents} argument.
    */
   off<K extends keyof T>(eventOrEvents?: K | K[], listener?: EventListener<T, K>): void;
   /**
-   * Behaves the same as { @link off:WITH_EVENTS | the overload which accepts one or more event names }, but removes the listener from _all_ events.
-   * @param listener (optional) the listener to remove. If not supplied, all listeners are removed.
+   * Remove one or more event listeners for all event types.
+   * @param listener An event listener. If not supplied, all listeners are removed.
    */
   off(listener?: EventListener<T, keyof T>): void;
   /**
@@ -227,9 +227,9 @@ export default class EventEmitter<T> {
   }
 
   /**
-   * Get the array of listeners for a given event; excludes once events
-   * @param event (optional) the name of the event, or none for 'any'
-   * @return array of events, or null if none
+   * Get the array of listeners for a given event. Excludes `once` events.
+   * @param event An event name.
+   * @return An array of events, or `null` if there are none.
    *
    * @typeParam K A type which allows a name of the properties of {@link T}. TypeScript will infer this type based on the {@link event} argument.
    */
@@ -251,8 +251,8 @@ export default class EventEmitter<T> {
    * @internal
    *
    * Emit an event
-   * @param event the event name
-   * @param arg the arguments to pass to the listener
+   * @param event An event name.
+   * @param arg The arguments to pass to the listener.
    */
   emit<K extends keyof T>(event: K, arg: T[K]) {
     const eventThis = { event };
@@ -285,16 +285,16 @@ export default class EventEmitter<T> {
 
   /**
    * {@label WITH_EVENTS}
-   * Listen for a single occurrence of an event
-   * @param event the name of the event to listen to
-   * @param listener (optional) the listener to be called
+   * Listen for a single occurrence of an event.
+   * @param event An event name.
+   * @param listener An event listener.
    *
    * @typeParam K A type which allows a name of one of the properties of {@link T}. TypeScript will infer this type based on the {@link event} argument.
    */
   once<K extends keyof T>(event: K, listener?: EventListener<T, K>): void | Promise<any>;
   /**
-   * Behaves the same as { @link once:WITH_EVENTS | the overload which accepts one or more event names }, but listens for _all_ events.
-   * @param listener (optional) the listener to be called
+   * Listen for a single occurrence of an event of any event type.
+   * @param listener An event listener.
    */
   once(listener?: EventListener<T, keyof T>): void | Promise<any>;
   /**


### PR DESCRIPTION
This PR updates all docstring comments. Broadly speaking, it:

* Consolidates the content taken from the docs site and class definitions.
* Removes labels of where content was sourced from. 
* Makes comments consistent where appropriate. 