### PR TITLE
Fix Ably-Agent usage

### DIFF
--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -42,7 +42,6 @@ describe('Spaces', () => {
     const spaces = new Spaces(client);
     expect(client.options.agents).toEqual({
       spaces: spaces.version,
-      'space-custom-client': true,
     });
   });
 
@@ -54,7 +53,6 @@ describe('Spaces', () => {
     expect(ablyClient.options.agents).toEqual({
       'some-client': '1.2.3',
       spaces: spaces.version,
-      'space-custom-client': true,
     });
   });
 });

--- a/src/Spaces.test.ts
+++ b/src/Spaces.test.ts
@@ -41,7 +41,7 @@ describe('Spaces', () => {
   it<SpacesTestContext>('applies the agent header to an existing SDK instance', ({ client }) => {
     const spaces = new Spaces(client);
     expect(client.options.agents).toEqual({
-      'ably-spaces': spaces.version,
+      spaces: spaces.version,
       'space-custom-client': true,
     });
   });
@@ -53,7 +53,7 @@ describe('Spaces', () => {
 
     expect(ablyClient.options.agents).toEqual({
       'some-client': '1.2.3',
-      'ably-spaces': spaces.version,
+      spaces: spaces.version,
       'space-custom-client': true,
     });
   });

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -50,7 +50,7 @@ class Spaces {
   }
 
   private addAgent(options: { agents?: Record<string, string | boolean> }) {
-    const agent = { spaces: this.version, 'space-custom-client': true };
+    const agent = { spaces: this.version };
     options.agents = { ...(options.agents ?? options.agents), ...agent };
   }
 

--- a/src/Spaces.ts
+++ b/src/Spaces.ts
@@ -50,7 +50,7 @@ class Spaces {
   }
 
   private addAgent(options: { agents?: Record<string, string | boolean> }) {
-    const agent = { 'ably-spaces': this.version, 'space-custom-client': true };
+    const agent = { spaces: this.version, 'space-custom-client': true };
     options.agents = { ...(options.agents ?? options.agents), ...agent };
   }
 


### PR DESCRIPTION
The spaces SDK needs only one Ably-Agent entry, `spaces`, so this replaces the current `ably-spaces` with `spaces` in the `agents` client options, and removes the unnecessary `space-custom-client` entry.