### PR TITLE
Downgrade to using nanoid@3 to support its use in CJS module bundle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     schedule:
       interval: "daily" # weekdays (Monday to Friday)
     labels: [ ] # prevent the default `dependencies` label from being added to pull requests
+    ignore:
+      - dependency-name: "nanoid"
+        update-types: ["version-update:semver-major"] # prevent from upgrading from nanoid@3, see for more info: https://github.com/ably/spaces/pull/307

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
         "ably": "^1.2.45",
         "classnames": "^2.3.2",
         "dayjs": "^1.11.9",
-        "nanoid": "^4.0.2",
+        "nanoid": "^3.3.7",
         "random-words": "^2.0.0",
         "react": "^18.2.0",
         "react-contenteditable": "^3.3.7",
@@ -41,15 +41,15 @@
     },
     "..": {
       "name": "@ably/spaces",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
-        "nanoid": "^5.0.2"
+        "nanoid": "^3.3.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.39.0",
-        "@rollup/plugin-node-resolve": "^15.2.1",
-        "@rollup/plugin-terser": "^0.4.3",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
         "@testing-library/react": "^14.0.0",
         "@types/express": "^4.17.18",
         "@types/react": "^18.2.23",
@@ -67,10 +67,10 @@
         "prettier": "^3.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.28.0",
+        "rollup": "^4.5.0",
         "ts-node": "^10.9.1",
         "typedoc": "^0.25.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.2.2",
         "vitest": "^0.34.3"
       },
       "peerDependencies": {
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -2968,10 +2968,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -19269,23 +19269,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -20445,8 +20428,8 @@
       "version": "file:..",
       "requires": {
         "@playwright/test": "^1.39.0",
-        "@rollup/plugin-node-resolve": "^15.2.1",
-        "@rollup/plugin-terser": "^0.4.3",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@rollup/plugin-terser": "^0.4.4",
         "@testing-library/react": "^14.0.0",
         "@types/express": "^4.17.18",
         "@types/react": "^18.2.23",
@@ -20461,14 +20444,14 @@
         "eslint-plugin-security": "^1.7.1",
         "express": "^4.18.2",
         "jsdom": "^22.1.0",
-        "nanoid": "^5.0.2",
+        "nanoid": "^3.3.7",
         "prettier": "^3.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.28.0",
+        "rollup": "^4.5.0",
         "ts-node": "^10.9.1",
         "typedoc": "^0.25.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.2.2",
         "vitest": "^0.34.3"
       }
     },
@@ -22420,9 +22403,9 @@
       }
     },
     "nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -34461,13 +34444,6 @@
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
-        }
       }
     },
     "postcss-import": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
     "ably": "^1.2.45",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.9",
-    "nanoid": "^4.0.2",
+    "nanoid": "^3.3.7",
     "random-words": "^2.0.0",
     "react": "^18.2.0",
     "react-contenteditable": "^3.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
-        "nanoid": "^5.0.2"
+        "nanoid": "^3.3.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.39.0",
@@ -4906,9 +4906,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.3.tgz",
-      "integrity": "sha512-I7X2b22cxA4LIHXPSqbBCEQSL+1wv8TuoefejsX4HFWyC6jc5JG7CEaxOltiKjc1M+YCS2YkrZZcj4+dytw9GA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -4916,10 +4916,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -5343,24 +5343,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -10667,9 +10649,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.3.tgz",
-      "integrity": "sha512-I7X2b22cxA4LIHXPSqbBCEQSL+1wv8TuoefejsX4HFWyC6jc5JG7CEaxOltiKjc1M+YCS2YkrZZcj4+dytw9GA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -10961,14 +10943,6 @@
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "3.3.7",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-          "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-          "dev": true
-        }
       }
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vitest": "^0.34.3"
   },
   "dependencies": {
-    "nanoid": "^5.0.2"
+    "nanoid": "^3.3.7"
   },
   "peerDependencies": {
     "ably": "^1.2.46",


### PR DESCRIPTION
Resolves #306

Starting from nanoid v4, it only works with ESM projects. We need to support both CJS and ESM bundles for the `spaces` SDK, so we have the following options to use the nanoid package:

1. Replace `require('nanoid')` imports with async `await import('nanoid')`. This solution is not suitable as the methods we currently use nanoid in are not async, and changing them to async will create cascading effects for a bunch of other methods and change the public API for users.
2. Replace the nanoid package with an in-project utility function to generate ids. This may be undesired since nanoid uses different `crypto` packages for its browser and Node.js bundles with some other platform-specific optimizations. Including them locally would not be a trivial change.
3. Downgrade to using nanoid v3, which supports both CJS and ESM and is still [being supported](https://github.com/ai/nanoid?tab=readme-ov-file#install) by the developer. This is the option implemented in this PR.

This PR also disables major version updates for `nanoid` package by GitHub dependabot.