### PR TITLE
Change cursors batch time formula on presence update

### DIFF
--- a/src/Cursors.test.ts
+++ b/src/Cursors.test.ts
@@ -116,7 +116,7 @@ describe('Cursors', () => {
       vi.spyOn(channel.presence, 'get').mockImplementation(createPresenceCount(2));
       await cursors['onPresenceUpdate']();
       expect(batching.shouldSend).toBeTruthy();
-      expect(batching.batchTime).toEqual(50);
+      expect(batching.batchTime).toEqual(25);
     });
 
     it<CursorsTestContext>('batchTime is updated when multiple people are present', async ({
@@ -126,7 +126,7 @@ describe('Cursors', () => {
     }) => {
       vi.spyOn(channel.presence, 'get').mockImplementation(createPresenceCount(2));
       await cursors['onPresenceUpdate']();
-      expect(batching.batchTime).toEqual(50);
+      expect(batching.batchTime).toEqual(25);
     });
 
     describe('pushCursorPosition', () => {

--- a/src/Cursors.ts
+++ b/src/Cursors.ts
@@ -105,7 +105,11 @@ export default class Cursors extends EventEmitter<CursorsEventMap> {
     const channel = this.getChannel();
     const cursorsMembers = await channel.presence.get();
     this.cursorBatching.setShouldSend(cursorsMembers.length > 1);
-    this.cursorBatching.setBatchTime(cursorsMembers.length * this.options.outboundBatchInterval);
+    /**
+     * Since server-side batching is automically enabled for cursors channels, we can now adjust the client-side batching interval more granularly.
+     * E.g. multiply the configured outboundBatchInterval by groups of 100 members instead of the total number of members.
+     */
+    this.cursorBatching.setBatchTime(Math.ceil(cursorsMembers.length / 100) * this.options.outboundBatchInterval);
   }
 
   private isUnsubscribed() {


### PR DESCRIPTION
https://ably.atlassian.net/browse/REA-1868

This PR changes the rate at which we adapt the (client-side) batch time, multiplying the `outboundBatchInterval` by slots of 100s instead of multiplying this value with the number of presence members.

This change and smoothing of client-side batching interval is incentivised by the addition of server-side batching, which is now enabled by default for cursors channels.