### PR TITLE
Release/0.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: 'write'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18.13.0'
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and publish
         run: |
           npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.5.2
+
+No breaking changes were introduced in this release.
+
+This is a patch release to fix the release process.
+
 ## v0.5.1
 
 No breaking changes were introduced in this release.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also use Spaces with a CDN, such as [unpkg](https://www.unpkg.com/):
 
 ```html
 <script src="https://cdn.ably.com/lib/ably.min-2.js"></script>
-<script src="https://cdn.ably.com/spaces/0.5.1/iife/index.bundle.js"></script>
+<script src="https://cdn.ably.com/spaces/0.5.2/iife/index.bundle.js"></script>
 ```
 
 After this, instantiate the SDK in the same way as in the NPM option above:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably/spaces",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably/spaces",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "ISC",
       "dependencies": {
         "nanoid": "^3.3.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/spaces",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // Manually update when bumping version
-const VERSION = '0.5.1';
+const VERSION = '0.5.2';
 export { VERSION };


### PR DESCRIPTION
This is a patch release to fix the release process:

- Remove the `contents: write` permission from the release job since that overwrites the OIDC permissions, and is not needed for anything else
- Use a more recent Node.js version which comes with an npm version which supports OIDC authentication