### PR TITLE
chore: update Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: renovatebot/github-action@v42.0.4
+      - uses: renovatebot/github-action@v46.1.13
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary
- update the self-hosted Renovate workflow from `renovatebot/github-action@v42.0.4` to `v46.1.13`
- keep the existing config file and `RENOVATE_TOKEN` wiring unchanged

## Verification
- `git diff --check`

This is a workflow-only maintenance update, so I did not run the project test suite.
