### PR TITLE
ci: GitHub Actions workflow security cleanup

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -49,5 +49,8 @@ jobs:
           npm ci
           npm run build
         # Note: If you modify what we upload to the CDN, you must make sure you keep the `test:cdn-bundle` NPM script in sync with your changes.
-      - run: |
-          aws s3 cp ./dist/iife/index.bundle.js s3://${{ github.event.inputs.bucket }}/spaces/${{ github.event.inputs.version }}/iife/index.bundle.js
+      - env:
+          BUCKET: ${{ github.event.inputs.bucket }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          aws s3 cp ./dist/iife/index.bundle.js "s3://${BUCKET}/spaces/${VERSION}/iife/index.bundle.js"

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.inputs.version }}
+          persist-credentials: false
       - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/${{ github.event.inputs.role-to-assume }}

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -28,15 +28,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.inputs.version }}
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/${{ github.event.inputs.role-to-assume }}
           aws-region: us-east-1
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 18
       - name: Install dependencies and build

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -20,6 +20,8 @@ on:
           - "prod-ably-sdk-cdn"
           - "nonprod-ably-sdk-cdn"
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -66,6 +69,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
       deployments: write
     steps:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -10,8 +10,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - run: npm ci
@@ -19,8 +19,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - run: npm ci
@@ -28,8 +28,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - run: npm ci
@@ -37,10 +37,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - run: npm ci
@@ -48,8 +48,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - run: npm ci
@@ -60,8 +60,8 @@ jobs:
       id-token: write
       deployments: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - name: Install Package Dependencies
@@ -71,17 +71,17 @@ jobs:
       - name: Build Documentation
         run: npm run docs
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         env:
           ably_aws_account_id_sdk: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}
         # do not run if these variables are not available; they will not be available for anybody outside the Ably org
-        if: ${{ env.ably_aws_account_id_sdk != '' }} 
+        if: ${{ env.ably_aws_account_id_sdk != '' }}
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-spaces
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v1
+        uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1
         env:
           ably_aws_account_id_sdk: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}
         # do not run if these variables are not available; they will not be available for anybody outside the Ably org
@@ -93,10 +93,10 @@ jobs:
   test-cdn-bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
       - run: npm ci

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
@@ -20,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
@@ -29,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
@@ -40,6 +46,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
@@ -49,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
@@ -61,6 +70,8 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18
@@ -96,6 +107,7 @@ jobs:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          # v4 does not enable caching by default; this is a no-op on v4 and
+          # explicitly opts out once v5 (which caches by default) is adopted.
+          package-manager-cache: false
       - name: Install dependencies and publish
         run: |
           npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,9 +10,9 @@ jobs:
     name: Renovate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: renovatebot/github-action@v46.1.13
+      - uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,6 +5,9 @@ on:
   # Run every week on Monday 9:00:
   - cron: '0 9 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   renovate:
     name: Renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
         with:


### PR DESCRIPTION
Routine hygiene pass over the four GitHub Actions workflows in this
  repo, addressing findings from a security audit. The changes are
  split into five commits, one per finding type:

  - pin actions to commit SHAs (tag kept as a trailing comment)
  - set persist-credentials: false on every checkout step
  - add explicit least-privilege permissions blocks
  - move workflow_dispatch inputs in cdn.yml through env vars instead
    of inline shell template expansion
  - explicitly opt out of package-manager caching on the release
    workflow's setup-node

  No behavioural change is expected: pinned SHAs resolve to the same
  commits the existing tags point at today, and the cdn.yml shell
  command produces the same S3 URL it did before.